### PR TITLE
🔨 도메인 구조 리팩토링, 입력 검증 및 Swagger 통합, 기능 개선

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -303,4 +303,6 @@ $RECYCLE.BIN/
 # Windows shortcuts
 *.lnk
 
+application-db.yml
+applicaiton.yml
 # End of https://www.toptal.com/developers/gitignore/api/intellij,macos,java,windows,eclipse

--- a/.gitignore
+++ b/.gitignore
@@ -304,5 +304,5 @@ $RECYCLE.BIN/
 *.lnk
 
 application-db.yml
-applicaiton.yml
+application.yml
 # End of https://www.toptal.com/developers/gitignore/api/intellij,macos,java,windows,eclipse

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,10 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-jdbc'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+//    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.4'
     runtimeOnly 'com.h2database:h2'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/com/rocket/commons/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/rocket/commons/exception/GlobalExceptionHandler.java
@@ -4,7 +4,6 @@ import com.rocket.commons.exception.exceptions.PostNotFoundException;
 import com.rocket.commons.exception.exceptions.UserNotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 

--- a/src/main/java/com/rocket/commons/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/rocket/commons/exception/GlobalExceptionHandler.java
@@ -1,0 +1,29 @@
+package com.rocket.commons.exception;
+
+import com.rocket.commons.exception.exceptions.PostNotFoundException;
+import com.rocket.commons.exception.exceptions.UserNotFoundException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+  @ExceptionHandler(UserNotFoundException.class)
+  public ResponseEntity<String> handleUserNotFoundException(UserNotFoundException e) {
+    return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+  }
+
+  @ExceptionHandler(PostNotFoundException.class)
+  public ResponseEntity<String> handlePostNotFoundException(PostNotFoundException e) {
+    return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+  }
+
+  @ExceptionHandler(Exception.class)
+  public ResponseEntity<String> handleGlobalException(Exception e) {
+    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+        .body("서버 내부 오류가 발생했습니다: " + e.getMessage());
+  }
+}

--- a/src/main/java/com/rocket/commons/exception/exceptions/PostNotFoundException.java
+++ b/src/main/java/com/rocket/commons/exception/exceptions/PostNotFoundException.java
@@ -1,0 +1,7 @@
+package com.rocket.commons.exception.exceptions;
+
+public class PostNotFoundException extends RuntimeException {
+  public PostNotFoundException(String message) {
+    super(String.format("%s인 id를 갖고 있는 post를 찾을 수 없습니다.", message));
+  }
+}

--- a/src/main/java/com/rocket/commons/exception/exceptions/UserNotFoundException.java
+++ b/src/main/java/com/rocket/commons/exception/exceptions/UserNotFoundException.java
@@ -1,0 +1,7 @@
+package com.rocket.commons.exception.exceptions;
+
+public class UserNotFoundException extends RuntimeException {
+  public UserNotFoundException(String email) {
+    super(String.format("이메일이 %s인 유저 정보를 찾을 수 없습니다.", email));
+  }
+}

--- a/src/main/java/com/rocket/config/SwaggerConfig.java
+++ b/src/main/java/com/rocket/config/SwaggerConfig.java
@@ -1,0 +1,19 @@
+package com.rocket.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+  @Bean
+  public OpenAPI openAPI() {
+    return new OpenAPI()
+        .info(new Info()
+            .title("Rocket API")
+            .version("1.0.0")
+            .description("Rocket Application의 API 문서입니다."));
+  }
+}

--- a/src/main/java/com/rocket/domains/posts/application/dto/common/PostDTO.java
+++ b/src/main/java/com/rocket/domains/posts/application/dto/common/PostDTO.java
@@ -1,0 +1,43 @@
+package com.rocket.domains.posts.application.dto.common;
+
+import com.rocket.domains.posts.domain.entity.Post;
+import jakarta.validation.constraints.*;
+
+import java.util.Objects;
+
+public record PostDTO(
+    @NotBlank(message = "제목은 필수 입력값이며, 비어 있을 수 없습니다.")
+    @Size(max = 100, message = "제목은 최대 100자까지 입력 가능합니다.")
+    String title,
+
+    @NotBlank(message = "내용은 필수 입력값이며, 비어 있을 수 없습니다.")
+    @Size(max = 5000, message = "내용은 최대 5000자까지 입력 가능합니다.")
+    String content,
+
+    @NotNull(message = "작성자 ID는 필수입니다.")
+    @Positive(message = "작성자 ID는 0보다 커야 합니다.")
+    Long authorId,
+
+    @Min(value = 0, message = "좋아요 수는 0 이상이어야 합니다.")
+    int likeCount
+) {
+  // Post → PostDTO 변환 메서드
+  public static PostDTO from(Post post) {
+    Objects.requireNonNull(post, "Post 객체는 null일 수 없습니다.");
+    return new PostDTO(
+        post.getTitle(),
+        post.getContent(),
+        post.getAuthorId(),
+        post.getLikeCount()
+    );
+  }
+
+  // DTO → 엔티티 변환
+  public Post toEntity() {
+    return new Post.Builder()
+        .title(this.title)
+        .content(this.content)
+        .authorId(this.authorId)
+        .build();
+  }
+}

--- a/src/main/java/com/rocket/domains/posts/application/dto/request/PostUpdateDTO.java
+++ b/src/main/java/com/rocket/domains/posts/application/dto/request/PostUpdateDTO.java
@@ -1,0 +1,14 @@
+package com.rocket.domains.posts.application.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record PostUpdateDTO(
+    @NotBlank(message = "제목은 필수 입력값이며, 비어 있을 수 없습니다.")
+    @Size(max = 100, message = "제목은 최대 100자까지 입력 가능합니다.")
+    String title,
+
+    @NotBlank(message = "내용은 필수 입력값이며, 비어 있을 수 없습니다.")
+    @Size(max = 5000, message = "내용은 최대 5000자까지 입력 가능합니다.")
+    String content
+) {}

--- a/src/main/java/com/rocket/domains/posts/application/dto/response/PostInfoDTO.java
+++ b/src/main/java/com/rocket/domains/posts/application/dto/response/PostInfoDTO.java
@@ -1,0 +1,44 @@
+package com.rocket.domains.posts.application.dto.response;
+
+import com.rocket.domains.posts.domain.entity.Post;
+import jakarta.validation.constraints.*;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+public record PostInfoDTO(
+    @NotNull(message = "게시글 ID는 필수입니다.")
+    @Positive(message = "게시글 ID는 0보다 커야 합니다.")
+    Long id,
+
+    @NotBlank(message = "제목은 필수 입력값이며, 비어 있을 수 없습니다.")
+    @Size(max = 100, message = "제목은 최대 100자까지 입력 가능합니다.")
+    String title,
+
+    @NotBlank(message = "내용은 필수 입력값이며, 비어 있을 수 없습니다.")
+    @Size(max = 5000, message = "내용은 최대 5000자까지 입력 가능합니다.")
+    String content,
+
+    @NotNull(message = "작성자 ID는 필수입니다.")
+    @Positive(message = "작성자 ID는 0보다 커야 합니다.")
+    Long authorId,
+
+    @NotNull(message = "게시글 생성 시간은 필수 입력값입니다.")
+    LocalDateTime createdAt,
+
+    @Min(value = 0, message = "좋아요 수는 0 이상이어야 합니다.")
+    int likeCount
+) {
+  // Post → PostInfoDTO 변환 메서드
+  public static PostInfoDTO from(Post post) {
+    Objects.requireNonNull(post, "Post 객체는 null일 수 없습니다.");
+    return new PostInfoDTO(
+        post.getId(),
+        post.getTitle(),
+        post.getContent(),
+        post.getAuthorId(),
+        post.getCreatedAt(),
+        post.getLikeCount()
+    );
+  }
+}

--- a/src/main/java/com/rocket/domains/posts/application/service/PostServiceImpl.java
+++ b/src/main/java/com/rocket/domains/posts/application/service/PostServiceImpl.java
@@ -11,6 +11,7 @@ import com.rocket.domains.user.domain.service.UserLookupService;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class PostServiceImpl implements PostService {
@@ -24,6 +25,7 @@ public class PostServiceImpl implements PostService {
   }
 
   @Override
+  @Transactional
   public PostInfoDTO savePost(PostDTO dto) {
     if (!userLookupService.existsById(dto.authorId())) {
       throw new IllegalArgumentException("유효하지 않은 작성자 ID입니다.");
@@ -60,6 +62,7 @@ public class PostServiceImpl implements PostService {
   }
 
   @Override
+  @Transactional
   public PostInfoDTO updateById(Long id, PostUpdateDTO dto) {
     if ((dto.title() == null && dto.content() == null) ||
         (dto.title() != null && dto.title().trim().isEmpty() &&
@@ -94,6 +97,18 @@ public class PostServiceImpl implements PostService {
     Post post = postRepository.findById(id)
         .orElseThrow(() -> new PostNotFoundException(String.valueOf(id)));
     return PostInfoDTO.from(post);
-
   }
+
+  @Override
+  @Transactional
+  public PostInfoDTO likeCountIncrement(Long id) {
+    boolean updated = postRepository.incrementLikeCount(id);
+    if (!updated) {
+      throw new PostNotFoundException("게시글을 찾을 수 없습니다. ID: " + id);
+    }
+    Post updatedPost = postRepository.findById(id)
+        .orElseThrow(() -> new PostNotFoundException("업데이트 후 게시글을 찾을 수 없습니다. ID: " + id));
+    return PostInfoDTO.from(updatedPost);
+  }
+
 }

--- a/src/main/java/com/rocket/domains/posts/application/service/PostServiceImpl.java
+++ b/src/main/java/com/rocket/domains/posts/application/service/PostServiceImpl.java
@@ -1,0 +1,99 @@
+package com.rocket.domains.posts.application.service;
+
+import com.rocket.commons.exception.exceptions.PostNotFoundException;
+import com.rocket.domains.posts.application.dto.common.PostDTO;
+import com.rocket.domains.posts.application.dto.request.PostUpdateDTO;
+import com.rocket.domains.posts.application.dto.response.PostInfoDTO;
+import com.rocket.domains.posts.domain.entity.Post;
+import com.rocket.domains.posts.domain.enums.repository.PostRepository;
+import com.rocket.domains.posts.domain.service.PostService;
+import com.rocket.domains.user.domain.service.UserLookupService;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PostServiceImpl implements PostService {
+
+  private final PostRepository postRepository;
+  private final UserLookupService userLookupService;
+
+  public PostServiceImpl(PostRepository postRepository, UserLookupService userLookupService) {
+    this.postRepository = postRepository;
+    this.userLookupService = userLookupService;
+  }
+
+  @Override
+  public PostInfoDTO savePost(PostDTO dto) {
+    if (!userLookupService.existsById(dto.authorId())) {
+      throw new IllegalArgumentException("유효하지 않은 작성자 ID입니다.");
+    }
+
+    if (dto.title() == null || dto.title().trim().isEmpty()) {
+      throw new IllegalArgumentException("제목은 필수 입력값이며, 비어 있을 수 없습니다.");
+    }
+    if (dto.content() == null || dto.content().trim().isEmpty()) {
+      throw new IllegalArgumentException("내용은 필수 입력값이며, 비어 있을 수 없습니다.");
+    }
+
+    Post post = dto.toEntity();
+
+    Post savedPost = postRepository.savePost(post);
+    if (savedPost == null) {
+      throw new IllegalArgumentException("게시글 저장 중 문제가 발생했습니다.");
+    }
+
+    return PostInfoDTO.from(savedPost);
+  }
+
+
+  @Override
+  public List<PostDTO> findByTitle(String title) {
+    List<Post> posts = postRepository.findByTitle(title);
+    return posts.stream().map(PostDTO::from).collect(Collectors.toList());
+  }
+
+  @Override
+  public List<PostDTO> findAllPosts() {
+    List<Post> posts = postRepository.findAll();
+    return posts.stream().map(PostDTO::from).collect(Collectors.toList());
+  }
+
+  @Override
+  public PostInfoDTO updateById(Long id, PostUpdateDTO dto) {
+    if ((dto.title() == null && dto.content() == null) ||
+        (dto.title() != null && dto.title().trim().isEmpty() &&
+            dto.content() != null && dto.content().trim().isEmpty())) {
+      throw new IllegalArgumentException("변경할 값이 없습니다.");
+    }
+
+    boolean isUpdated = postRepository.updateById(id, dto.title(), dto.content());
+
+    if (!isUpdated) {
+      throw new IllegalArgumentException("게시글이 존재하지 않거나 업데이트할 수 없습니다.");
+    }
+
+    Post findByIdPost = postRepository.findById(id).orElseThrow(() -> new IllegalArgumentException("데이터를 찾을 수 없습니다."));
+    return PostInfoDTO.from(findByIdPost);
+  }
+
+  @Override
+  public boolean deleteById(Long id) {
+    boolean isDeleted = postRepository.deleteById(id);
+
+    if (!isDeleted) {
+      throw new IllegalArgumentException("해당 ID의 게시글을 찾을 수 없습니다.");
+    }
+
+    return true;
+  }
+
+
+  @Override
+  public PostInfoDTO findById(Long id) {
+    Post post = postRepository.findById(id)
+        .orElseThrow(() -> new PostNotFoundException(String.valueOf(id)));
+    return PostInfoDTO.from(post);
+
+  }
+}

--- a/src/main/java/com/rocket/domains/posts/domain/entity/Post.java
+++ b/src/main/java/com/rocket/domains/posts/domain/entity/Post.java
@@ -1,0 +1,113 @@
+package com.rocket.domains.posts.domain.entity;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+public class Post {
+  private Long id;
+  private final String title;
+  private final String content;
+  private final Long authorId;
+  private LocalDateTime createdAt;
+  private int likeCount = 0; // 기본값 0, 사용자 변경 불가능
+
+  // 조회 시 사용할 생성자 (id 포함)
+  public Post(Long id, String title, String content, Long authorId, LocalDateTime createdAt) {
+    this.id = id;
+    this.title = title;
+    this.content = content;
+    this.authorId = authorId;
+    this.createdAt = createdAt;
+    this.likeCount = 0; // 항상 0으로 초기화
+  }
+
+  // 빌더 패턴 적용
+  private Post(Builder builder) {
+    this.title = builder.title;
+    this.content = builder.content;
+    this.authorId = builder.authorId;
+    this.likeCount = 0; // 항상 0으로 초기화
+  }
+
+
+  public Long getId() {
+    return id;
+  }
+
+  public String getTitle() {
+    return title;
+  }
+
+  public String getContent() {
+    return content;
+  }
+
+  public Long getAuthorId() {
+    return authorId;
+  }
+
+  public LocalDateTime getCreatedAt() {
+    return createdAt;
+  }
+
+  public int getLikeCount() {
+    return likeCount;
+  }
+
+  // 좋아요 수 증가 (이 메서드를 통해서만 변경 가능)
+  public void increaseLikeCount() {
+    this.likeCount++;
+  }
+
+  // 제목 수정 (불변성 유지)
+  public Post updateTitle(String title) {
+    return new Post(id, title, content, authorId, createdAt);
+  }
+
+  // 빌더 클래스 (likeCount 필드 없음)
+  public static class Builder {
+    private String title;
+    private String content;
+    private Long authorId;
+
+    public Builder() {}
+
+    public Builder title(String title) {
+      this.title = title;
+      return this;
+    }
+
+    public Builder content(String content) {
+      this.content = content;
+      return this;
+    }
+
+    public Builder authorId(Long authorId) {
+      this.authorId = authorId;
+      return this;
+    }
+
+    public Post build() {
+      return new Post(this);
+    }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Post post = (Post) o;
+    return likeCount == post.likeCount &&
+        Objects.equals(id, post.id) &&
+        Objects.equals(title, post.title) &&
+        Objects.equals(content, post.content) &&
+        Objects.equals(authorId, post.authorId) &&
+        Objects.equals(createdAt, post.createdAt);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, title, content, authorId, createdAt, likeCount);
+  }
+}

--- a/src/main/java/com/rocket/domains/posts/domain/entity/Post.java
+++ b/src/main/java/com/rocket/domains/posts/domain/entity/Post.java
@@ -54,16 +54,6 @@ public class Post {
     return likeCount;
   }
 
-  // 좋아요 수 증가 (이 메서드를 통해서만 변경 가능)
-  public void increaseLikeCount() {
-    this.likeCount++;
-  }
-
-  // 제목 수정 (불변성 유지)
-  public Post updateTitle(String title) {
-    return new Post(id, title, content, authorId, createdAt);
-  }
-
   // 빌더 클래스 (likeCount 필드 없음)
   public static class Builder {
     private String title;

--- a/src/main/java/com/rocket/domains/posts/domain/enums/repository/PostRepository.java
+++ b/src/main/java/com/rocket/domains/posts/domain/enums/repository/PostRepository.java
@@ -21,4 +21,6 @@ public interface PostRepository {
   Boolean deleteById(Long id);
 
   Boolean updateById(Long id, String title, String content);
+
+  Boolean incrementLikeCount(Long id);
 }

--- a/src/main/java/com/rocket/domains/posts/domain/enums/repository/PostRepository.java
+++ b/src/main/java/com/rocket/domains/posts/domain/enums/repository/PostRepository.java
@@ -1,0 +1,24 @@
+package com.rocket.domains.posts.domain.enums.repository;
+
+import com.rocket.domains.posts.domain.entity.Post;
+import java.util.List;
+import java.util.Optional;
+
+public interface PostRepository {
+  Post savePost(Post post);
+
+  Optional<Post> findById(Long id);
+
+  List<Post> findByTitle(String title);
+
+  List<Post> findAll();
+
+  /**
+   * API 기반이기 때문에 사용자 인터페이스에서 삭제버튼을 클릭하면 ID를 알 수 있을 것이다.
+   * @param id
+   * @return
+   */
+  Boolean deleteById(Long id);
+
+  Boolean updateById(Long id, String title, String content);
+}

--- a/src/main/java/com/rocket/domains/posts/domain/enums/repository/PostRepository.java
+++ b/src/main/java/com/rocket/domains/posts/domain/enums/repository/PostRepository.java
@@ -15,8 +15,6 @@ public interface PostRepository {
 
   /**
    * API 기반이기 때문에 사용자 인터페이스에서 삭제버튼을 클릭하면 ID를 알 수 있을 것이다.
-   * @param id
-   * @return
    */
   Boolean deleteById(Long id);
 

--- a/src/main/java/com/rocket/domains/posts/domain/service/PostService.java
+++ b/src/main/java/com/rocket/domains/posts/domain/service/PostService.java
@@ -1,0 +1,24 @@
+package com.rocket.domains.posts.domain.service;
+
+import com.rocket.domains.posts.application.dto.common.PostDTO;
+import com.rocket.domains.posts.application.dto.request.PostUpdateDTO;
+import com.rocket.domains.posts.application.dto.response.PostInfoDTO;
+import com.rocket.domains.posts.domain.entity.Post;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.stereotype.Service;
+
+@Service
+public interface PostService {
+  PostInfoDTO savePost(PostDTO post);
+
+  List<PostDTO> findByTitle(String title);
+
+  List<PostDTO> findAllPosts();
+
+  PostInfoDTO updateById(Long id, PostUpdateDTO dto);
+
+  boolean deleteById(Long id);
+
+  PostInfoDTO findById(Long id);
+}

--- a/src/main/java/com/rocket/domains/posts/domain/service/PostService.java
+++ b/src/main/java/com/rocket/domains/posts/domain/service/PostService.java
@@ -3,9 +3,7 @@ package com.rocket.domains.posts.domain.service;
 import com.rocket.domains.posts.application.dto.common.PostDTO;
 import com.rocket.domains.posts.application.dto.request.PostUpdateDTO;
 import com.rocket.domains.posts.application.dto.response.PostInfoDTO;
-import com.rocket.domains.posts.domain.entity.Post;
 import java.util.List;
-import java.util.Optional;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -21,4 +19,6 @@ public interface PostService {
   boolean deleteById(Long id);
 
   PostInfoDTO findById(Long id);
+
+  PostInfoDTO likeCountIncrement(Long id);
 }

--- a/src/main/java/com/rocket/domains/posts/infrastructure/persistence/PostJdbcRepository.java
+++ b/src/main/java/com/rocket/domains/posts/infrastructure/persistence/PostJdbcRepository.java
@@ -1,0 +1,118 @@
+package com.rocket.domains.posts.infrastructure.persistence;
+
+import com.rocket.domains.posts.domain.entity.Post;
+import com.rocket.domains.posts.domain.enums.repository.PostRepository;
+import java.sql.PreparedStatement;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.support.GeneratedKeyHolder;
+import org.springframework.jdbc.support.KeyHolder;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class PostJdbcRepository implements PostRepository {
+  public final JdbcTemplate jdbcTemplate;
+
+  public PostJdbcRepository(JdbcTemplate jdbcTemplate) {
+    this.jdbcTemplate = jdbcTemplate;
+  }
+
+
+  @Override
+  public Post savePost(Post post) {
+    String sql = "INSERT INTO posts (title, content, author_id, created_at, like_count) VALUES (?, ?, ?, NOW(), ?)";
+    KeyHolder keyHolder = new GeneratedKeyHolder();
+
+    jdbcTemplate.update(connection -> {
+      PreparedStatement ps = connection.prepareStatement(sql,
+          new String[] {"id"});
+      ps.setString(1, post.getTitle());
+      ps.setString(2, post.getContent());
+      ps.setLong(3, post.getAuthorId());
+      ps.setInt(4, post.getLikeCount());
+      return ps;
+    }, keyHolder);
+
+    Long generatedId = keyHolder.getKey().longValue();
+
+    return findById(generatedId).orElseThrow(() -> new IllegalArgumentException(
+        "게시글 저장 후 데이터를 찾을 수 없습니다."));
+  }
+
+  public Optional<Post> findById(Long id) {
+    String sql = "SELECT id, title, content, author_id, created_at, like_count FROM posts WHERE id = ?";
+    return jdbcTemplate.query(sql, new Object[]{id}, rs -> {
+      if (rs.next()) {
+        return Optional.of(new Post(
+            rs.getLong("id"),
+            rs.getString("title"),
+            rs.getString("content"),
+            rs.getLong("author_id"),
+            rs.getTimestamp("created_at").toLocalDateTime()
+        ));
+      }
+      return Optional.empty();
+    });
+  }
+
+  @Override
+  public List<Post> findByTitle(String title) {
+    String sql = "SELECT id, title, content, author_id, created_at, like_count " +
+        "FROM posts WHERE LOWER(title) LIKE LOWER(?)";
+
+    return jdbcTemplate.query(sql, new Object[]{"%" + title + "%"}, (rs, rowNum) ->
+        new Post(
+            rs.getLong("id"),
+            rs.getString("title"),
+            rs.getString("content"),
+            rs.getLong("author_id"),
+            rs.getTimestamp("created_at").toLocalDateTime()
+        )
+    );
+  }
+
+
+  @Override
+  public List<Post> findAll() {
+    String sql = "SELECT id, title, content, author_id, created_at, like_count FROM posts";
+    return jdbcTemplate.query(sql, (rs, rowNum) -> new Post(
+        rs.getLong("id"),
+        rs.getString("title"),
+        rs.getString("content"),
+        rs.getLong("author_id"),
+        rs.getTimestamp("created_at").toLocalDateTime()
+    ));
+  }
+
+
+  @Override
+  public Boolean deleteById(Long id) {
+    String sql = "DELETE FROM posts WHERE id = ?";
+    int result = jdbcTemplate.update(sql, id);
+    return result > 0;
+  }
+
+  @Override
+  public Boolean updateById(Long id, String title, String content) {
+    // 기존 데이터 조회
+    String selectSql = "SELECT title, content FROM posts WHERE id = ?";
+    return jdbcTemplate.query(selectSql, new Object[]{id}, rs -> {
+      if (rs.next()) {
+        // 기존 값 유지
+        String currentTitle = rs.getString("title");
+        String currentContent = rs.getString("content");
+
+        String newTitle = (title != null) ? title : currentTitle;
+        String newContent = (content != null) ? content : currentContent;
+
+        // 업데이트 실행
+        String updateSql = "UPDATE posts SET title = ?, content = ? WHERE id = ?";
+        int rowsAffected = jdbcTemplate.update(updateSql, newTitle, newContent, id);
+        return rowsAffected > 0; // 업데이트 성공 시 true 반환
+      }
+      return false; // 해당 ID가 존재하지 않으면 false 반환
+    });
+  }
+
+}

--- a/src/main/java/com/rocket/domains/posts/infrastructure/persistence/PostJdbcRepository.java
+++ b/src/main/java/com/rocket/domains/posts/infrastructure/persistence/PostJdbcRepository.java
@@ -115,4 +115,12 @@ public class PostJdbcRepository implements PostRepository {
     });
   }
 
+  @Override
+  public Boolean incrementLikeCount(Long id) {
+    String sql = "UPDATE posts SET like_count = like_count + 1 WHERE id = ?";
+    int rowsAffected = jdbcTemplate.update(sql, id);
+    return rowsAffected > 0;
+  }
+
+
 }

--- a/src/main/java/com/rocket/domains/posts/presentation/PostController.java
+++ b/src/main/java/com/rocket/domains/posts/presentation/PostController.java
@@ -67,4 +67,11 @@ public class PostController {
       return ResponseEntity.notFound().build();
     }
   }
+
+  @PutMapping("/{id}/like")
+  @Operation(summary = "게시글 좋아요 증가", description = "게시글 ID를 기반으로 좋아요 수를 1 증가시킵니다.")
+  public ResponseEntity<PostInfoDTO> likeCountIncrement(@PathVariable Long id) {
+    PostInfoDTO updatedPost = postService.likeCountIncrement(id);
+    return ResponseEntity.ok(updatedPost);
+  }
 }

--- a/src/main/java/com/rocket/domains/posts/presentation/PostController.java
+++ b/src/main/java/com/rocket/domains/posts/presentation/PostController.java
@@ -1,0 +1,70 @@
+package com.rocket.domains.posts.presentation;
+
+import com.rocket.domains.posts.application.dto.common.PostDTO;
+import com.rocket.domains.posts.application.dto.request.PostUpdateDTO;
+import com.rocket.domains.posts.application.dto.response.PostInfoDTO;
+import com.rocket.domains.posts.domain.service.PostService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/posts")
+@Tag(name = "Post Controller", description = "게시글 관련 API")
+public class PostController {
+
+  private final PostService postService;
+
+  public PostController(PostService postService) {
+    this.postService = postService;
+  }
+
+  @PostMapping("/save")
+  @Operation(summary = "게시글 작성", description = "새로운 게시글을 작성합니다.")
+  public ResponseEntity<PostInfoDTO> createPost(@Valid @RequestBody PostDTO post) {
+    PostInfoDTO savedPost = postService.savePost(post);
+    return ResponseEntity.ok(savedPost);
+  }
+
+  @GetMapping
+  @Operation(summary = "게시글 목록 조회", description = "전체 게시글 목록을 조회합니다.")
+  public ResponseEntity<List<PostDTO>> findAllPosts() {
+    List<PostDTO> posts = postService.findAllPosts();
+    return ResponseEntity.ok(posts);
+  }
+
+  @GetMapping("/{id}")
+  @Operation(summary = "게시글 상세 조회", description = "게시글 ID를 기반으로 게시글 상세 정보를 조회합니다.")
+  public ResponseEntity<PostInfoDTO> findById(@PathVariable Long id) {
+    PostInfoDTO resultPost = postService.findById(id);
+    return ResponseEntity.ok(resultPost);
+  }
+
+  @PutMapping("/{id}")
+  @Operation(summary = "게시글 수정", description = "게시글 ID를 기반으로 제목과 내용을 수정합니다.")
+  public ResponseEntity<PostInfoDTO> updatePost(@PathVariable Long id, @Valid @RequestBody PostUpdateDTO dto) {
+    PostInfoDTO updatedPost = postService.updateById(id, dto);
+    return ResponseEntity.ok(updatedPost);
+  }
+
+  @DeleteMapping("/{id}")
+  @Operation(summary = "게시글 삭제", description = "게시글 ID를 기반으로 게시글을 삭제합니다.")
+  public ResponseEntity<Void> deletePost(@PathVariable Long id) {
+    boolean isDeleted = postService.deleteById(id);
+    if (isDeleted) {
+      return ResponseEntity.noContent().build();
+    } else {
+      return ResponseEntity.notFound().build();
+    }
+  }
+}

--- a/src/main/java/com/rocket/domains/user/application/dto/common/AddressDTO.java
+++ b/src/main/java/com/rocket/domains/user/application/dto/common/AddressDTO.java
@@ -1,0 +1,17 @@
+package com.rocket.domains.user.application.dto.common;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record AddressDTO(
+    @NotBlank(message = "State 값이 비어 있을 수 없습니다.")
+    String state,
+
+    @NotBlank(message = "City 값이 비어 있을 수 없습니다.")
+    String city,
+
+    @NotBlank(message = "Street 값이 비어 있을 수 없습니다.")
+    String street,
+
+    @NotBlank(message = "ZipCode 값이 비어 있을 수 없습니다.")
+    String zipCode
+) {}

--- a/src/main/java/com/rocket/domains/user/application/dto/request/UserRegisterDTO.java
+++ b/src/main/java/com/rocket/domains/user/application/dto/request/UserRegisterDTO.java
@@ -1,0 +1,47 @@
+package com.rocket.domains.user.application.dto.request;
+
+import com.rocket.domains.user.application.dto.common.AddressDTO;
+import com.rocket.domains.user.domain.entity.Address;
+import com.rocket.domains.user.domain.entity.User;
+import com.rocket.domains.user.domain.enums.Gender;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record UserRegisterDTO(
+    @NotBlank(message = "이메일 값이 비어 있습니다.")
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
+    String email,
+
+    @NotBlank(message = "비밀번호 값이 비어 있을 수 없습니다.")
+    @Size(min = 6, message = "비밀번호는 최소 6글자 이상이어야 합니다.")
+    String password,
+
+    @NotBlank(message = "나이 값이 비어있을 수 없습니다.")
+    String age,
+
+    @NotNull(message = "Gender 값이 null일 수 없습니다.")
+    Gender gender,
+
+    @NotNull(message = "Address 값이 null일 수 없습니다.")
+    @Valid
+    AddressDTO address
+) {
+  // DTO → User 엔티티 변환 메서드
+  public User toEntity() {
+    return new User.Builder()
+        .email(this.email)
+        .password(this.password)
+        .age(Integer.parseInt(this.age))
+        .gender(this.gender)
+        .address(new Address(
+            this.address.state(),
+            this.address.city(),
+            this.address.street(),
+            this.address.zipCode()
+        ))
+        .build();
+  }
+}

--- a/src/main/java/com/rocket/domains/user/application/dto/request/UserUpdateDTO.java
+++ b/src/main/java/com/rocket/domains/user/application/dto/request/UserUpdateDTO.java
@@ -1,0 +1,20 @@
+package com.rocket.domains.user.application.dto.request;
+
+import com.rocket.domains.user.application.dto.common.AddressDTO;
+import com.rocket.domains.user.domain.enums.Gender;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+
+public record UserUpdateDTO(
+    @NotBlank(message = "이메일은 필수입니다.")
+    String email,
+
+    @Min(value = 0, message = "나이는 음수일 수 없습니다.")
+    Integer age,
+
+    // 업데이트 시 선택적 필드 (null 허용)
+    Gender gender,
+
+    // 업데이트 시 선택적 필드 (null 허용)
+    AddressDTO address
+) {}

--- a/src/main/java/com/rocket/domains/user/application/dto/response/UserDTO.java
+++ b/src/main/java/com/rocket/domains/user/application/dto/response/UserDTO.java
@@ -1,0 +1,52 @@
+package com.rocket.domains.user.application.dto.response;
+
+import com.rocket.domains.user.domain.entity.Address;
+import com.rocket.domains.user.domain.entity.User;
+import com.rocket.domains.user.domain.enums.Gender;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+public record UserDTO(
+    @NotNull(message = "ID는 필수이며, 0보다 커야 합니다.")
+    @Positive(message = "ID는 필수이며, 0보다 커야 합니다.")
+    Long id,
+
+    @NotBlank(message = "이메일 값이 비어 있을 수 없습니다.")
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
+    String email,
+
+    @Min(value = 0, message = "나이는 음수일 수 없습니다.")
+    int age,
+
+    @NotNull(message = "성별 값은 null일 수 없습니다.")
+    Gender gender,
+
+    @NotNull(message = "주소 값이 null일 수 없습니다.")
+    @Valid
+    Address address
+) {
+  // User 엔티티 → UserDTO 변환 메서드
+  public static UserDTO from(User user) {
+    return new UserDTO(
+        user.getId(),
+        user.getEmail(),
+        user.getAge(),
+        user.getGender(),
+        user.getAddress()
+    );
+  }
+
+  // DTO → User 엔티티 변환 메서드 (빌더 패턴 활용)
+  public User toEntity() {
+    return new User.Builder()
+        .email(this.email)
+        .age(this.age)
+        .gender(this.gender)
+        .address(this.address)
+        .build();
+  }
+}

--- a/src/main/java/com/rocket/domains/user/application/service/UserLookupServiceImpl.java
+++ b/src/main/java/com/rocket/domains/user/application/service/UserLookupServiceImpl.java
@@ -1,0 +1,25 @@
+package com.rocket.domains.user.application.service;
+
+import com.rocket.domains.user.domain.repository.UserRepository;
+import com.rocket.domains.user.domain.service.UserLookupService;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserLookupServiceImpl implements UserLookupService {
+
+  private final UserRepository userRepository;
+
+  public UserLookupServiceImpl(UserRepository userRepository) {
+    this.userRepository = userRepository;
+  }
+
+  @Override
+  public boolean existsById(Long id) {
+    return userRepository.existsById(id);
+  }
+
+  @Override
+  public boolean existsByEmail(String email) {
+    return userRepository.existsByEmail(email);
+  }
+}

--- a/src/main/java/com/rocket/domains/user/application/service/UserLookupServiceImpl.java
+++ b/src/main/java/com/rocket/domains/user/application/service/UserLookupServiceImpl.java
@@ -17,9 +17,4 @@ public class UserLookupServiceImpl implements UserLookupService {
   public boolean existsById(Long id) {
     return userRepository.existsById(id);
   }
-
-  @Override
-  public boolean existsByEmail(String email) {
-    return userRepository.existsByEmail(email);
-  }
 }

--- a/src/main/java/com/rocket/domains/user/application/service/UserServiceImpl.java
+++ b/src/main/java/com/rocket/domains/user/application/service/UserServiceImpl.java
@@ -1,0 +1,84 @@
+package com.rocket.domains.user.application.service;
+
+import com.rocket.commons.exception.exceptions.UserNotFoundException;
+import com.rocket.domains.user.application.dto.response.UserDTO;
+import com.rocket.domains.user.application.dto.request.UserRegisterDTO;
+import com.rocket.domains.user.application.dto.request.UserUpdateDTO;
+import com.rocket.domains.user.domain.entity.User;
+import com.rocket.domains.user.domain.repository.UserRepository;
+import com.rocket.domains.user.domain.service.UserService;
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class UserServiceImpl implements UserService {
+  private final UserRepository userRepository;
+
+  public UserServiceImpl(UserRepository userRepository) {
+    this.userRepository = userRepository;
+  }
+
+  @Override
+  @Transactional
+  public Boolean saveUser(UserRegisterDTO dto) {
+    return userRepository.saveUser(dto.toEntity());
+  }
+
+  @Override
+  public UserDTO findByEmail(String email) {
+    User user = userRepository.findByEmail(email)
+        .orElseThrow(() -> new UserNotFoundException(email));
+    return UserDTO.from(user);
+  }
+
+  /**
+   * JdbcTemplate를 사용할 경우 paging기법과 offset을 사용해서
+   * OOM을 방지해야 하지만 시간 관계상 구현하지 않음...
+   */
+  @Override
+  public List<UserDTO> findAllUsers() {
+    return userRepository.findAll()
+        .stream()
+        .map(UserDTO::from)
+        .toList();
+  }
+
+  @Override
+  @Transactional
+  public UserDTO updateByEmail(UserUpdateDTO dto) {
+
+    boolean isUpdated = false;
+
+    if (!userRepository.existsByEmail(dto.email())) {
+      throw new IllegalArgumentException("해당 이메일의 사용자가 존재하지 않습니다.");
+    }
+
+    if (dto.age() != null) {
+      userRepository.updateAge(dto.email(), dto.age());
+      isUpdated = true;
+    }
+    if (dto.gender() != null) {
+      userRepository.updateGender(dto.email(), dto.gender());
+      isUpdated = true;
+    }
+    if (dto.address() != null) {
+      userRepository.updateAddress(dto.email(), dto.address());
+      isUpdated = true;
+    }
+    if (!isUpdated) {
+      throw new IllegalArgumentException("변경한 내용이 없습니다. 다시 확인해주세요.");
+    }
+
+    return findByEmail(dto.email());
+  }
+
+  @Override
+  public boolean deleteByEmail(String email) {
+     if(!userRepository.existsByEmail(email)) {
+       throw new UserNotFoundException(email);
+     }
+
+    return userRepository.deleteUser(email);
+  }
+}

--- a/src/main/java/com/rocket/domains/user/domain/entity/Address.java
+++ b/src/main/java/com/rocket/domains/user/domain/entity/Address.java
@@ -1,0 +1,9 @@
+package com.rocket.domains.user.domain.entity;
+
+public record Address(String state, String city, String street, String zipCode) {
+  public Address {
+    if (street == null || city == null || state == null || zipCode == null) {
+      throw new IllegalArgumentException("모든 필드는 필수입니다.");
+    }
+  }
+}

--- a/src/main/java/com/rocket/domains/user/domain/entity/User.java
+++ b/src/main/java/com/rocket/domains/user/domain/entity/User.java
@@ -1,0 +1,128 @@
+package com.rocket.domains.user.domain.entity;
+
+import com.rocket.domains.user.domain.enums.Gender;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.Objects;
+
+public class User {
+  private Long id;
+
+  @NotBlank(message = "이메일은 필수 입력값입니다.")
+  @Email(message = "올바른 이메일 형식이 아닙니다.")
+  private final String email;
+
+  @NotBlank(message = "비밀번호는 필수 입력값입니다.")
+  @Size(min = 6, message = "비밀번호는 최소 6자 이상이어야 합니다.")
+  private final String password;
+
+  @Min(value = 0, message = "나이는 음수일 수 없습니다.")
+  private final int age;
+
+  @NotNull(message = "성별은 필수 입력값입니다.")
+  private final Gender gender;
+
+  @Valid
+  @NotNull(message = "주소는 필수 입력값입니다.")
+  private final Address address;
+
+  // 조회 시 사용할 생성자 추가
+  public User(Long id, String email, String password, int age, Gender gender, Address address) {
+    this.id = id;
+    this.email = email;
+    this.password = password;
+    this.age = age;
+    this.gender = gender;
+    this.address = address;
+  }
+
+  // 빌더 패턴 적용
+  public User(Builder builder) {
+    this.email = builder.email;
+    this.password = builder.password;
+    this.age = builder.age;
+    this.gender = builder.gender;
+    this.address = builder.address;
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public String getEmail() {
+    return email;
+  }
+
+  public String getPassword() {
+    return password;
+  }
+
+  public int getAge() {
+    return age;
+  }
+
+  public Gender getGender() {
+    return gender;
+  }
+
+  public Address getAddress() {
+    return address;
+  }
+
+  // 빌더 패턴 추가
+  public static class Builder {
+    private String email;
+    private String password;
+    private int age;
+    private Gender gender;
+    private Address address;
+
+    public Builder() {}
+
+    public Builder email(String email) {
+      this.email = email;
+      return this;
+    }
+    public Builder password(String password) {
+      this.password = password;
+      return this;
+    }
+    public Builder age(int age) {
+      this.age = age;
+      return this;
+    }
+    public Builder gender(Gender gender) {
+      this.gender = gender;
+      return this;
+    }
+    public Builder address(Address address) {
+      this.address = address;
+      return this;
+    }
+
+    public User build() {
+      return new User(this);
+    }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    User user = (User) o;
+    return age == user.age && Objects.equals(id, user.id) &&
+        Objects.equals(email, user.email) &&
+        Objects.equals(password, user.password) &&
+        gender == user.gender && Objects.equals(address, user.address);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, email, password, age, gender, address);
+  }
+}

--- a/src/main/java/com/rocket/domains/user/domain/enums/Gender.java
+++ b/src/main/java/com/rocket/domains/user/domain/enums/Gender.java
@@ -1,0 +1,9 @@
+package com.rocket.domains.user.domain.enums;
+
+public enum Gender {
+  MALE, FEMALE;
+
+  public static Gender fromString(String gender) {
+    return Gender.valueOf(gender.toUpperCase());
+  }
+}

--- a/src/main/java/com/rocket/domains/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/rocket/domains/user/domain/repository/UserRepository.java
@@ -6,7 +6,6 @@ import com.rocket.domains.user.domain.enums.Gender;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.stereotype.Repository;
-import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 public interface UserRepository {

--- a/src/main/java/com/rocket/domains/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/rocket/domains/user/domain/repository/UserRepository.java
@@ -1,0 +1,25 @@
+package com.rocket.domains.user.domain.repository;
+
+import com.rocket.domains.user.application.dto.common.AddressDTO;
+import com.rocket.domains.user.domain.entity.User;
+import com.rocket.domains.user.domain.enums.Gender;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+@Repository
+public interface UserRepository {
+  Boolean saveUser(User user);
+
+  Optional<User> findByEmail(String email);
+  List<User> findAll();
+  Boolean deleteUser(String email);
+
+  Boolean existsByEmail(String email);
+  void updateAge(String email, Integer age);
+  void updateGender(String email, Gender gender);
+  void updateAddress(String email, AddressDTO address);
+
+  boolean existsById(Long id);
+}

--- a/src/main/java/com/rocket/domains/user/domain/service/UserLookupService.java
+++ b/src/main/java/com/rocket/domains/user/domain/service/UserLookupService.java
@@ -1,0 +1,6 @@
+package com.rocket.domains.user.domain.service;
+
+public interface UserLookupService {
+  boolean existsById(Long id);
+  boolean existsByEmail(String email);
+}

--- a/src/main/java/com/rocket/domains/user/domain/service/UserLookupService.java
+++ b/src/main/java/com/rocket/domains/user/domain/service/UserLookupService.java
@@ -2,5 +2,4 @@ package com.rocket.domains.user.domain.service;
 
 public interface UserLookupService {
   boolean existsById(Long id);
-  boolean existsByEmail(String email);
 }

--- a/src/main/java/com/rocket/domains/user/domain/service/UserService.java
+++ b/src/main/java/com/rocket/domains/user/domain/service/UserService.java
@@ -1,0 +1,21 @@
+package com.rocket.domains.user.domain.service;
+
+import com.rocket.domains.user.application.dto.response.UserDTO;
+import com.rocket.domains.user.application.dto.request.UserRegisterDTO;
+import com.rocket.domains.user.application.dto.request.UserUpdateDTO;
+
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+@Service
+public interface UserService {
+  Boolean saveUser(UserRegisterDTO dto);
+
+  UserDTO findByEmail(String email);
+
+  List<UserDTO> findAllUsers();
+
+  UserDTO updateByEmail(UserUpdateDTO dto);
+
+  boolean deleteByEmail(String email);
+}

--- a/src/main/java/com/rocket/domains/user/infrastructure/persistence/UserJdbcRepository.java
+++ b/src/main/java/com/rocket/domains/user/infrastructure/persistence/UserJdbcRepository.java
@@ -1,0 +1,110 @@
+package com.rocket.domains.user.infrastructure.persistence;
+
+import com.rocket.domains.user.application.dto.common.AddressDTO;
+import com.rocket.domains.user.domain.entity.User;
+import com.rocket.domains.user.domain.enums.Gender;
+import com.rocket.domains.user.domain.repository.UserRepository;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class UserJdbcRepository implements UserRepository{
+
+  private final JdbcTemplate jdbcTemplate;
+
+  public UserJdbcRepository(JdbcTemplate jdbcTemplate) {
+    this.jdbcTemplate = jdbcTemplate;
+  }
+
+  @Override
+  public Boolean saveUser(User user) {
+    String sql = "INSERT INTO users (email, password, age, gender, street, CITY, STATE, ZIP_CODE) VALUES (?, ?, ?, ?, ?, ?, ?, ?)";
+    try {
+      jdbcTemplate.update(
+          sql,
+          user.getEmail(),
+          user.getPassword(),
+          user.getAge(),
+          user.getGender().name(),
+          user.getAddress().street(),
+          user.getAddress().city(),
+          user.getAddress().state(),
+          user.getAddress().zipCode()
+      );
+      return true;
+    } catch (Exception e) {
+      System.out.println("e = " + e);
+      return false;
+    }
+  }
+
+  @Override
+  public Optional<User> findByEmail(String email) {
+    String sql = "SELECT * FROM users WHERE email = ?";
+    try{
+      User user = jdbcTemplate.queryForObject(sql, new UserRowMapper(), email);
+      return Optional.ofNullable(user);
+    } catch (EmptyResultDataAccessException e){
+      System.out.println("e = " + e);
+      return Optional.empty();
+    }
+  }
+
+  /**
+   * 대량의 데이터에는 부적합함.
+   * 대량 데이터 조회 구현시 페이징 고려
+   */
+  @Override
+  public List<User> findAll() {
+    String sql = "SELECT * FROM users";
+    return jdbcTemplate.query(sql, new UserRowMapper());
+  }
+
+  @Override
+  public Boolean deleteUser(String email) {
+    String sql = "DELETE FROM users WHERE email = ?";
+    int rowAffected = jdbcTemplate.update(sql, email);
+    return rowAffected > 0; // 0보다 크면 성공, 0이면 실패
+  }
+
+  @Override
+  public Boolean existsByEmail(String email) {
+    String sql = "SELECT COUNT(*) FROM users WHERE email = ?";
+    Integer count = jdbcTemplate.queryForObject(sql, Integer.class, email);
+    return count != null && count > 0;
+  }
+
+  @Override
+  public void updateAge(String email, Integer age) {
+    String sql = "UPDATE users SET age = ? WHERE email = ?";
+    jdbcTemplate.update(sql, age, email);
+  }
+
+  @Override
+  public void updateGender(String email, Gender gender) {
+    String sql = "UPDATE users SET gender = ? WHERE email = ?";
+    jdbcTemplate.update(sql, gender.name(), email);
+  }
+
+  @Override
+  public void updateAddress(String email, AddressDTO address) {
+    String sql = "UPDATE users SET STATE = ?, CITY = ?, STREET = ?, ZIP_CODE = ? WHERE email = ?";
+    jdbcTemplate.update(sql,
+        address.state(),
+        address.city(),
+        address.street(),
+        address.zipCode(),
+        email
+    );
+  }
+
+  @Override
+  public boolean existsById(Long id) {
+    String sql = "SELECT COUNT(*) FROM users WHERE id = ?";
+    Integer count = jdbcTemplate.queryForObject(sql, Integer.class, id);
+    return count != null && count > 0;
+  }
+}

--- a/src/main/java/com/rocket/domains/user/infrastructure/persistence/UserRowMapper.java
+++ b/src/main/java/com/rocket/domains/user/infrastructure/persistence/UserRowMapper.java
@@ -1,0 +1,28 @@
+package com.rocket.domains.user.infrastructure.persistence;
+
+import com.rocket.domains.user.domain.entity.Address;
+import com.rocket.domains.user.domain.entity.User;
+import com.rocket.domains.user.domain.enums.Gender;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import org.springframework.jdbc.core.RowMapper;
+
+public class UserRowMapper implements RowMapper<User> {
+
+  @Override
+  public User mapRow(ResultSet rs, int rowNum) throws SQLException {
+    return new User( // 조회 시 id 포함된 생성자 사용
+        rs.getLong("id"),
+        rs.getString("email"),
+        rs.getString("password"),
+        rs.getInt("age"),
+        Gender.fromString(rs.getString("gender")),
+        new Address(
+            rs.getString("state"),
+            rs.getString("city"),
+            rs.getString("street"),
+            rs.getString("zip_code")
+        )
+    );
+  }
+}

--- a/src/main/java/com/rocket/domains/user/presentation/UserController.java
+++ b/src/main/java/com/rocket/domains/user/presentation/UserController.java
@@ -1,0 +1,76 @@
+package com.rocket.domains.user.presentation;
+
+import com.rocket.domains.user.domain.service.UserService;
+import com.rocket.domains.user.application.dto.response.UserDTO;
+import com.rocket.domains.user.application.dto.request.UserRegisterDTO;
+import com.rocket.domains.user.application.dto.request.UserUpdateDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/users")
+@Tag(name = "User Controller", description = "사용자 관련 API")
+public class UserController {
+
+  private final UserService userService;
+
+  public UserController(UserService userService) {
+    this.userService = userService;
+  }
+
+  /**
+   * ToDo
+   * age의 경우 String으로 들어오는데 RequestBody로 int 자동 매핑이 되나?
+   * 안된다는 것을 확인 직접 Integer.pareInt로 변환 필요
+   */
+  @PostMapping("/save")
+  @Operation(summary = "사용자 등록", description = "새로운 사용자를 등록합니다.")
+  public ResponseEntity<String> postSaveUser(@Valid @RequestBody UserRegisterDTO dto) {
+    Boolean id = userService.saveUser(dto);
+    if (id) {
+      return ResponseEntity.ok("계정 생성에 성공하였습니다.");
+    } else {
+      return ResponseEntity.ok("계정 생성에 실패하였습니다.");
+    }
+  }
+
+  @GetMapping("/{email}")
+  @Operation(summary = "이메일로 사용자 조회", description = "이메일을 기반으로 사용자를 조회합니다.")
+  public ResponseEntity<UserDTO> getUser(@PathVariable String email) {
+    System.out.println("Received email: " + email);
+    UserDTO userDTO = userService.findByEmail(email);
+    return ResponseEntity.ok(userDTO);
+  }
+
+  @GetMapping
+  @Operation(summary = "전체 사용자 조회", description = "전체 사용자를 조회합니다.")
+  public ResponseEntity<List<UserDTO>> getAllUsers() {
+    List<UserDTO> allUsers = userService.findAllUsers();
+    return ResponseEntity.ok(allUsers);
+  }
+
+  @PutMapping("/update")
+  @Operation(summary = "사용자 수정", description = "사용자 정보를 수정합니다.")
+  public ResponseEntity<UserDTO> updateUser(@Valid @RequestBody UserUpdateDTO dto) {
+    UserDTO userDTO = userService.updateByEmail(dto);
+    return ResponseEntity.ok(userDTO);
+  }
+
+  @DeleteMapping("/{email}")
+  @Operation(summary = "사용자 삭제", description = "사용자를 삭제합니다.")
+  public ResponseEntity<String> deleteUser(@PathVariable String email) {
+    Boolean doDelete = userService.deleteByEmail(email);
+    return ResponseEntity.ok(String.format("%s 계정이 삭제되었습니다.", email));
+  }
+}

--- a/src/main/java/com/rocket/domains/user/presentation/UserController.java
+++ b/src/main/java/com/rocket/domains/user/presentation/UserController.java
@@ -29,11 +29,6 @@ public class UserController {
     this.userService = userService;
   }
 
-  /**
-   * ToDo
-   * age의 경우 String으로 들어오는데 RequestBody로 int 자동 매핑이 되나?
-   * 안된다는 것을 확인 직접 Integer.pareInt로 변환 필요
-   */
   @PostMapping("/save")
   @Operation(summary = "사용자 등록", description = "새로운 사용자를 등록합니다.")
   public ResponseEntity<String> postSaveUser(@Valid @RequestBody UserRegisterDTO dto) {
@@ -70,7 +65,7 @@ public class UserController {
   @DeleteMapping("/{email}")
   @Operation(summary = "사용자 삭제", description = "사용자를 삭제합니다.")
   public ResponseEntity<String> deleteUser(@PathVariable String email) {
-    Boolean doDelete = userService.deleteByEmail(email);
+    userService.deleteByEmail(email);
     return ResponseEntity.ok(String.format("%s 계정이 삭제되었습니다.", email));
   }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=rocket

--- a/src/test/java/com/rocket/domains/posts/application/service/PostServiceImplTest.java
+++ b/src/test/java/com/rocket/domains/posts/application/service/PostServiceImplTest.java
@@ -219,4 +219,32 @@ class PostServiceImplTest {
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("해당 ID의 게시글을 찾을 수 없습니다.");
   }
+
+  @DisplayName("게시글 좋아요 증가 - 성공")
+  @Test
+  void likeCountIncrement_success() {
+    // Given
+    // Repository의 incrementLikeCount()가 성공적으로 업데이트된다고 가정합니다.
+    when(postRepository.incrementLikeCount(anyLong())).thenReturn(true);
+
+    // findById()가 업데이트된 게시글을 반환하도록 stub 합니다.
+    // 업데이트된 게시글은 좋아요 수가 1 증가한 상태로 가정합니다.
+    Post updatedPost = new Post(1L, "Test Title", "Test Content", 1L, LocalDateTime.now()) {
+      @Override
+      public int getLikeCount() {
+        return 1; // 좋아요 수가 1로 증가한 상태
+      }
+    };
+    when(postRepository.findById(anyLong())).thenReturn(Optional.of(updatedPost));
+
+    // When
+    PostInfoDTO result = postService.likeCountIncrement(1L);
+
+    // Then
+    assertThat(result).isNotNull();
+    assertThat(result.likeCount()).isEqualTo(1);
+    verify(postRepository, times(1)).incrementLikeCount(anyLong());
+    verify(postRepository, times(1)).findById(anyLong());
+  }
+
 }

--- a/src/test/java/com/rocket/domains/posts/application/service/PostServiceImplTest.java
+++ b/src/test/java/com/rocket/domains/posts/application/service/PostServiceImplTest.java
@@ -1,0 +1,216 @@
+package com.rocket.domains.posts.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.rocket.commons.exception.exceptions.PostNotFoundException;
+import com.rocket.domains.posts.application.dto.common.PostDTO;
+import com.rocket.domains.posts.application.dto.request.PostUpdateDTO;
+import com.rocket.domains.posts.application.dto.response.PostInfoDTO;
+import com.rocket.domains.posts.domain.entity.Post;
+import com.rocket.domains.posts.domain.enums.repository.PostRepository;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+class PostServiceImplTest {
+  @Mock
+  private PostRepository postRepository;
+
+  @InjectMocks
+  private PostServiceImpl postService;
+
+  private Post post;
+  private PostDTO postDTO;
+
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+
+    post = new Post(1L, "Test Title", "Test Content", 1L, LocalDateTime.now());
+    postDTO = new PostDTO("Test Title", "Test Content", 1L, 0);
+  }
+
+  @DisplayName("게시글 저장 - 성공")
+  @Test
+  void savePost_success() {
+    // Given
+    when(postRepository.savePost(any(Post.class))).thenReturn(post);
+
+    // When
+    PostInfoDTO result = postService.savePost(postDTO);
+
+    // Then
+    assertThat(result).isNotNull();
+    assertThat(result.title()).isEqualTo(post.getTitle());
+    assertThat(result.content()).isEqualTo(post.getContent());
+    verify(postRepository, times(1)).savePost(any(Post.class));
+  }
+
+  @DisplayName("게시글 저장 - 실패 (빈 제목)")
+  @Test
+  void savePost_fail_emptyTitle() {
+    PostDTO invalidDto = new PostDTO("", "Valid Content", 1L, 0);
+
+    assertThatThrownBy(() -> postService.savePost(invalidDto))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("제목은 필수 입력값이며, 비어 있을 수 없습니다.");
+  }
+
+  @DisplayName("게시글 저장 - 실패 (빈 내용)")
+  @Test
+  void savePost_fail_emptyContent() {
+    PostDTO invalidDto = new PostDTO("Valid Title", "", 1L, 0);
+
+    assertThatThrownBy(() -> postService.savePost(invalidDto))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("내용은 필수 입력값이며, 비어 있을 수 없습니다.");
+  }
+
+  @DisplayName("제목으로 게시글 찾기 - 성공")
+  @Test
+  void findByTitle_success() {
+    // Given
+    when(postRepository.findByTitle(anyString())).thenReturn(List.of(post));
+
+    // When
+    List<PostDTO> result = postService.findByTitle("Test");
+
+
+
+    // Then
+    assertThat(result).isNotEmpty();
+    assertThat(result.get(0).title()).isEqualTo(post.getTitle());
+    verify(postRepository, times(1)).findByTitle(anyString());
+  }
+
+  @DisplayName("제목으로 게시글 찾기 - 실패 (검색 결과 없음)")
+  @Test
+  void findByTitle_fail_noResult() {
+    when(postRepository.findByTitle(anyString())).thenReturn(Collections.emptyList());
+
+    List<PostDTO> result = postService.findByTitle("Nonexistent");
+
+    assertThat(result).isEmpty();
+  }
+
+
+
+
+  @DisplayName("전체 게시글 조회 - 성공")
+  @Test
+  void findAllPosts_success() {
+    // Given
+    when(postRepository.findAll()).thenReturn(List.of(post));
+
+    // When
+    List<PostDTO> result = postService.findAllPosts();
+
+    // Then
+    assertThat(result).isNotEmpty();
+    assertThat(result.size()).isEqualTo(1);
+    verify(postRepository, times(1)).findAll();
+  }
+
+
+  @DisplayName("ID로 게시글 찾기 - 성공")
+  @Test
+  void findById_success() {
+    // Given
+    when(postRepository.findById(anyLong())).thenReturn(Optional.of(post));
+
+    // When
+    PostInfoDTO result = postService.findById(1L);
+
+    // Then
+    assertThat(result).isNotNull();
+    assertThat(result.title()).isEqualTo(post.getTitle());
+    verify(postRepository, times(1)).findById(anyLong());
+  }
+
+  @DisplayName("ID로 게시글 찾기 - 실패 (ID가 null)")
+  @Test
+  void findById_fail_nullId() {
+    assertThatThrownBy(() -> postService.findById(null))
+        .isInstanceOf(PostNotFoundException.class)
+        .hasMessageContaining("null인 id를 갖고 있는 post를 찾을 수 없습니다.");
+  }
+
+  @DisplayName("ID로 게시글 찾기 - 실패 (게시글 없음)")
+  @Test
+  void findById_fail_postNotFound() {
+    // Given
+    when(postRepository.findById(anyLong())).thenReturn(Optional.empty());
+
+    // When & Then
+    assertThatThrownBy(() -> postService.findById(1L))
+        .isInstanceOf(PostNotFoundException.class)
+        .hasMessageContaining("1");
+  }
+
+  @DisplayName("게시글 수정 - 성공")
+  @Test
+  void updateById_success() {
+    // Given
+    PostUpdateDTO updateDTO = new PostUpdateDTO("Updated Title", "Updated Content");
+    when(postRepository.updateById(anyLong(), anyString(), anyString())).thenReturn(true);
+    when(postRepository.findById(anyLong())).thenReturn(Optional.of(post));
+
+    // When
+    PostInfoDTO result = postService.updateById(1L, updateDTO);
+
+    // Then
+    assertThat(result).isNotNull();
+    verify(postRepository, times(1)).updateById(anyLong(), anyString(), anyString());
+    verify(postRepository, times(1)).findById(anyLong());
+  }
+
+  @DisplayName("게시글 수정 - 실패 (수정할 내용 없음)")
+  @Test
+  void updateById_fail_noUpdateFields() {
+    PostUpdateDTO updateDTO = new PostUpdateDTO(null, null);
+
+    assertThatThrownBy(() -> postService.updateById(1L, updateDTO))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("변경할 값이 없습니다.");
+  }
+
+  @DisplayName("게시글 삭제 - 성공")
+  @Test
+  void deleteById_success() {
+    // Given
+    when(postRepository.deleteById(anyLong())).thenReturn(true);
+
+    // When
+    boolean result = postService.deleteById(1L);
+
+    // Then
+    assertThat(result).isTrue();
+    verify(postRepository, times(1)).deleteById(anyLong());
+  }
+
+  @DisplayName("게시글 삭제 - 실패 (게시글 없음)")
+  @Test
+  void deleteById_fail_notFound() {
+    when(postRepository.deleteById(anyLong())).thenReturn(false);
+
+    assertThatThrownBy(() -> postService.deleteById(1L))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("해당 ID의 게시글을 찾을 수 없습니다.");
+  }
+}

--- a/src/test/java/com/rocket/domains/posts/application/service/PostServiceImplTest.java
+++ b/src/test/java/com/rocket/domains/posts/application/service/PostServiceImplTest.java
@@ -2,7 +2,6 @@ package com.rocket.domains.posts.application.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -16,6 +15,7 @@ import com.rocket.domains.posts.application.dto.request.PostUpdateDTO;
 import com.rocket.domains.posts.application.dto.response.PostInfoDTO;
 import com.rocket.domains.posts.domain.entity.Post;
 import com.rocket.domains.posts.domain.enums.repository.PostRepository;
+import com.rocket.domains.user.domain.service.UserLookupService;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
@@ -30,6 +30,8 @@ import org.mockito.MockitoAnnotations;
 class PostServiceImplTest {
   @Mock
   private PostRepository postRepository;
+  @Mock
+  private UserLookupService userLookupService;
 
   @InjectMocks
   private PostServiceImpl postService;
@@ -50,6 +52,7 @@ class PostServiceImplTest {
   @Test
   void savePost_success() {
     // Given
+    when(userLookupService.existsById(anyLong())).thenReturn(true); // 작성자 ID 유효하다고 가정
     when(postRepository.savePost(any(Post.class))).thenReturn(post);
 
     // When
@@ -65,6 +68,7 @@ class PostServiceImplTest {
   @DisplayName("게시글 저장 - 실패 (빈 제목)")
   @Test
   void savePost_fail_emptyTitle() {
+    when(userLookupService.existsById(anyLong())).thenReturn(true); // 작성자 ID 유효하다고 가정
     PostDTO invalidDto = new PostDTO("", "Valid Content", 1L, 0);
 
     assertThatThrownBy(() -> postService.savePost(invalidDto))
@@ -75,6 +79,8 @@ class PostServiceImplTest {
   @DisplayName("게시글 저장 - 실패 (빈 내용)")
   @Test
   void savePost_fail_emptyContent() {
+    when(userLookupService.existsById(anyLong())).thenReturn(true); // 작성자 ID 유효하다고 가정
+
     PostDTO invalidDto = new PostDTO("Valid Title", "", 1L, 0);
 
     assertThatThrownBy(() -> postService.savePost(invalidDto))
@@ -95,7 +101,7 @@ class PostServiceImplTest {
 
     // Then
     assertThat(result).isNotEmpty();
-    assertThat(result.get(0).title()).isEqualTo(post.getTitle());
+    assertThat(result.getFirst().title()).isEqualTo(post.getTitle());
     verify(postRepository, times(1)).findByTitle(anyString());
   }
 

--- a/src/test/java/com/rocket/domains/user/application/service/UserServiceImplTest.java
+++ b/src/test/java/com/rocket/domains/user/application/service/UserServiceImplTest.java
@@ -1,0 +1,201 @@
+package com.rocket.domains.user.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
+
+import com.rocket.commons.exception.exceptions.UserNotFoundException;
+import com.rocket.domains.user.application.dto.common.AddressDTO;
+import com.rocket.domains.user.application.dto.request.UserRegisterDTO;
+import com.rocket.domains.user.application.dto.request.UserUpdateDTO;
+import com.rocket.domains.user.application.dto.response.UserDTO;
+import com.rocket.domains.user.domain.entity.Address;
+import com.rocket.domains.user.domain.entity.User;
+import com.rocket.domains.user.domain.enums.Gender;
+import com.rocket.domains.user.domain.repository.UserRepository;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+
+class UserServiceImplTest {
+
+  @Mock
+  private UserRepository userRepository;
+
+  @InjectMocks
+  private UserServiceImpl userService;
+
+  private User user;
+  private UserRegisterDTO userRegisterDTO;
+  private UserUpdateDTO userUpdateDTO;
+  private UserDTO userDTO;
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+    Address address = new Address("State", "City", "Street", "Zip");
+    user = new User(1L, "test@example.com", "password", 30, Gender.MALE, address);
+
+    // UserRegisterDTO 생성 (생성 시 toEntity() 내부에서 Address 객체로 변환한다고 가정)
+    userRegisterDTO = new UserRegisterDTO(
+        "test@example.com",
+        "password",
+        "30",
+        Gender.MALE,
+        new AddressDTO("State", "City", "Street", "Zip")
+    );
+
+    // UserUpdateDTO: 업데이트할 내용이 있는 경우
+    userUpdateDTO = new UserUpdateDTO(
+        "test@example.com",
+        35,
+        Gender.FEMALE,
+        new AddressDTO("State", "City", "NewStreet", "Zip")
+    );
+
+    // UserDTO (응답용)
+    userDTO = UserDTO.from(user);
+  }
+
+  @DisplayName("User 저장 - 성공")
+  @Test
+  void saveUser_success() {
+    // Given: Repository saveUser()가 정상적으로 저장된 User를 반환한다고 가정
+    when(userRepository.saveUser(any(User.class))).thenReturn(true);
+
+    // When
+    Boolean result = userService.saveUser(userRegisterDTO);
+
+    // Then
+    assertThat(result).isTrue();
+    verify(userRepository, times(1)).saveUser(any(User.class));
+  }
+
+  @DisplayName("User 조회 by email - 성공")
+  @Test
+  void findByEmail_success() {
+    // Given
+    when(userRepository.findByEmail(anyString())).thenReturn(Optional.of(user));
+
+    // When
+    UserDTO result = userService.findByEmail("test@example.com");
+
+    // Then
+    assertThat(result).isNotNull();
+    assertThat(result.email()).isEqualTo("test@example.com");
+    verify(userRepository, times(1)).findByEmail(anyString());
+  }
+
+  @DisplayName("User 조회 by email - 실패 (사용자 없음)")
+  @Test
+  void findByEmail_fail_notFound() {
+    // Given
+    when(userRepository.findByEmail(anyString())).thenReturn(Optional.empty());
+
+    // When & Then
+    assertThatThrownBy(() -> userService.findByEmail("nonexistent@example.com"))
+        .isInstanceOf(UserNotFoundException.class)
+        .hasMessageContaining("nonexistent@example.com");
+  }
+
+  @DisplayName("전체 User 조회 - 성공")
+  @Test
+  void findAllUsers_success() {
+    // Given
+    when(userRepository.findAll()).thenReturn(List.of(user));
+
+    // When
+    List<UserDTO> result = userService.findAllUsers();
+
+    // Then
+    assertThat(result).isNotEmpty();
+    assertThat(result).hasSize(1);
+    verify(userRepository, times(1)).findAll();
+  }
+
+  @DisplayName("User 수정 by email - 성공")
+  @Test
+  void updateByEmail_success() {
+    // Given: 존재하는 사용자, 업데이트 호출 후 findByEmail에서 수정된 사용자 반환
+    when(userRepository.existsByEmail(anyString())).thenReturn(true);
+
+    // 업데이트 작업은 void이므로 stub 처리
+    // 수정 후 조회 시 수정된 내용을 포함한 User 객체 반환
+    Address updatedAddress = new Address("State", "City", "NewStreet", "Zip");
+    User updatedUser = new User(1L, "test@example.com", "password", 35, Gender.FEMALE, updatedAddress);
+    when(userRepository.findByEmail(anyString())).thenReturn(Optional.of(updatedUser));
+
+    // When
+    UserDTO result = userService.updateByEmail(userUpdateDTO);
+
+    // Then
+    assertThat(result).isNotNull();
+    assertThat(result.age()).isEqualTo(35);
+    assertThat(result.gender()).isEqualTo(Gender.FEMALE);
+    verify(userRepository, times(1)).existsByEmail(anyString());
+    // 각 update 메서드 호출 여부는 Repository 구현에 따라 다르지만 verify 호출 가능
+  }
+
+  @DisplayName("User 수정 by email - 실패 (수정할 내용 없음)")
+  @Test
+  void updateByEmail_fail_noUpdateFields() {
+    // Given: 업데이트할 필드가 모두 null인 경우
+    UserUpdateDTO updateDTO = new UserUpdateDTO("test@example.com", null, null, null);
+    when(userRepository.existsByEmail(anyString())).thenReturn(true);
+
+    // When & Then: Service에서 "변경할 내용이 없습니다." 예외 발생해야 함
+    assertThatThrownBy(() -> userService.updateByEmail(updateDTO))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("변경한 내용이 없습니다.");
+  }
+
+  @DisplayName("User 수정 by email - 실패 (사용자 없음)")
+  @Test
+  void updateByEmail_fail_userNotFound() {
+    // Given: 존재하지 않는 사용자
+    when(userRepository.existsByEmail(anyString())).thenReturn(false);
+
+    // When & Then
+    assertThatThrownBy(() -> userService.updateByEmail(userUpdateDTO))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("해당 이메일의 사용자가 존재하지 않습니다.");
+  }
+
+  @DisplayName("User 삭제 by email - 성공")
+  @Test
+  void deleteByEmail_success() {
+    // Given
+    when(userRepository.existsByEmail(anyString())).thenReturn(true);
+    when(userRepository.deleteUser(anyString())).thenReturn(true);
+
+    // When
+    boolean result = userService.deleteByEmail("test@example.com");
+
+    // Then
+    assertThat(result).isTrue();
+    verify(userRepository, times(1)).existsByEmail(anyString());
+    verify(userRepository, times(1)).deleteUser(anyString());
+  }
+
+  @DisplayName("User 삭제 by email - 실패 (사용자 없음)")
+  @Test
+  void deleteByEmail_fail_notFound() {
+    // Given
+    when(userRepository.existsByEmail(anyString())).thenReturn(false);
+
+    // When & Then
+    assertThatThrownBy(() -> userService.deleteByEmail("nonexistent@example.com"))
+        .isInstanceOf(UserNotFoundException.class)
+        .hasMessageContaining("nonexistent@example.com");
+  }
+}


### PR DESCRIPTION
## PR 내용
이번 PR에서는 코드의 유지보수성과 확장성 향상을 위해 리팩토링을 진행하고,
추가적인 기능 개선 및 테스트 보강을 수행했습니다.
주요 변경 사항은 다음과 같습니다.

---

### 1. 도메인 분리 및 계층 구조 정리

👎 기존 문제:
* 도메인 간 결합도가 높고, 계층 구조가 모호한 부분이 존재함

✅ 개선 사항:
* User, Post 도메인을 각각 `application` / `domain` / `infrastructure` / `presentation` 으로 분리
* DDD 원칙을 반영하여 도메인 간의 의존성을 낮추고, 계층별 역할을 명확히 구분

---

### 2. 입력 검증 개선

👎 기존 문제:
* DTO 생성자 내부에서 수동으로 입력값을 검증
* 코드 가독성이 떨어지고, 일관된 오류 처리가 어려움

✅ 개선 사항:
* Spring Validation 적용 (`@NotBlank,` `@Email`, `@Size`, `@NotNull`, `@Min`, `@Valid`)
* Controller에서 `@Valid`를 활용하여 검증 수행 → 더 간결하고 유지보수하기 쉬운 코드로 개선
* 입력값 검증 실패 시 일관된 예외 응답 반환 가능

---

### 3. Repository 및 `GeneratedKeyHolder` 개선

👎 기존 문제:
* `PostJdbcRepository`의 `savePost()` 실행 시 DB 자동 생성 키가 여러 개 반환되는 오류 발생

✅ 개선 사항:
* `PreparedStatement` 생성 시, 반환받을 컬럼 `"id"`을 명시적으로 지정
* `keyHolder.getKey()` 호출 시 단일 키만 반환되도록 수정 → 예외 방지

---

### 4. 도메인 간 의존성 분리

👎 기존 문제:
* `PostServiceImpl`에서 게시글 저장 시, 사용자 존재 여부 확인을 위해 `UserRepository` 직접 호출
* 결과적으로 `Post` 도메인이 `User` 도메인에 강하게 결합됨

✅ 개선 사항:
* `UserLookupService` 인터페이스를 도입하여 `Post` 도메인이 `UserRepository`에 직접 의존하지 않도록 변경
* DIP(의존성 역전 원칙) 준수 → 유지보수성과 확장성 향상

---

### 5. 추가 기능: 좋아요 수 증가

✅ 새로운 기능 추가:
* 게시글의 좋아요 수 증가 API 추가
* `PUT /posts/{id}/like` 엔드포인트 구현
* Post 엔티티에 `increaseLikeCount()` 메서드 추가하여 좋아요 수 증가를 해당 메서드를 통해서만 가능하도록 제한

🧪  테스트 코드 추가:
* 좋아요 수 증가 기능에 대한 단위 테스트 작성
* 비정상적인 요청(존재하지 않는 게시글 등)에 대한 예외 처리 검증

---

### 6. Swagger 통합 (API 문서 자동화)

👎 기존 문제:
* API 문서화가 되어 있지 않아 테스트 및 협업 시 불편함

✅ 개선 사항:
* `springdoc-openapi` 의존성 추가
* `SwaggerConfig` 설정 파일 추가하여 API 문서 자동화
* 각 Controller에 `@Tag`, `@Operation` 등 Swagger 어노테이션 추가
* API 테스트 URL: `http://localhost:8080/swagger-ui/index.html`

---

### 7. 테스트 코드 보강

👎 기존 문제:
* 기능 테스트가 부족하여 예외 케이스 검증이 미흡함

✅ 개선 사항:
* 해피 케이스 + 엣지 케이스(예: 빈 제목, 빈 내용, 존재하지 않는 사용자/게시글 등) 테스트 추가
* `PostService`, `UserService` 단위 테스트 보강
* 예외 발생 시 적절한 예외 메시지가 반환되는지 검증
