### PR TITLE
Feature/auth-test 인증/인가 기능에 대한 테스트 코드 전반 작성 및 예외 처리 개선

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -307,6 +307,7 @@ application-db.yml
 application.yml
 application-mysql.yml
 application-redis.yml
+application-test.yml
 docker-compose.yml
 .env
 # End of https://www.toptal.com/developers/gitignore/api/intellij,macos,java,windows,eclipse

--- a/src/main/java/com/rocket/commons/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/rocket/commons/exception/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.rocket.commons.exception;
 
 import com.rocket.commons.exception.exceptions.DuplicateEmailException;
 import com.rocket.commons.exception.exceptions.DuplicateLikeException;
+import com.rocket.commons.exception.exceptions.InvalidEmailFormatException;
 import com.rocket.commons.exception.exceptions.InvalidTokenException;
 import com.rocket.commons.exception.exceptions.LoginFailedException;
 import com.rocket.commons.exception.exceptions.PostNotFoundException;
@@ -11,6 +12,11 @@ import com.rocket.commons.exception.response.ErrorResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestHeaderException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -75,6 +81,62 @@ public class GlobalExceptionHandler {
         );
   }
 
+  @ExceptionHandler(MissingRequestHeaderException.class)
+  public ResponseEntity<ErrorResponse> handleMissingHeader(MissingRequestHeaderException ex,
+      HttpServletRequest request) {
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+        .body(ErrorResponse.of(400, "요청 헤더가 누락되었습니다.", ex.getMessage(), request.getRequestURI()));
+  }
+
+
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  public ResponseEntity<ErrorResponse> handleValidationError(MethodArgumentNotValidException ex,
+      HttpServletRequest request) {
+    String errorMessage = ex.getBindingResult().getFieldErrors().stream()
+        .map(error -> error.getDefaultMessage())
+        .findFirst()
+        .orElse("요청 값이 올바르지 않습니다.");
+
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+        .body(ErrorResponse.of(400, "요청 값이 올바르지 않습니다.", errorMessage, request.getRequestURI()));
+  }
+
+  @ExceptionHandler(HttpMessageNotReadableException.class)
+  public ResponseEntity<ErrorResponse> handleMessageNotReadable(HttpMessageNotReadableException ex,
+      HttpServletRequest request) {
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+        .body(ErrorResponse.of(400, "요청 값이 올바르지 않습니다.", ex.getMessage(), request.getRequestURI()));
+  }
+
+  @ExceptionHandler(HttpMediaTypeNotSupportedException.class)
+  public ResponseEntity<ErrorResponse> handleUnsupportedMediaType(
+      HttpMediaTypeNotSupportedException ex,
+      HttpServletRequest request) {
+    return ResponseEntity.status(HttpStatus.UNSUPPORTED_MEDIA_TYPE)
+        .body(ErrorResponse.of(415, "지원하지 않는 Content-Type입니다.", ex.getMessage(),
+            request.getRequestURI()));
+  }
+
+  @ExceptionHandler(MissingServletRequestParameterException.class)
+  public ResponseEntity<String> handleMissingParam(MissingServletRequestParameterException e) {
+    return ResponseEntity.badRequest().body("Missing required parameter: " + e.getParameterName());
+  }
+
+  @ExceptionHandler(InvalidEmailFormatException.class)
+  public ResponseEntity<ErrorResponse> handleInvalidEmailFormatException(
+      InvalidEmailFormatException ex,
+      HttpServletRequest request
+  ) {
+    ErrorResponse errorResponse = ErrorResponse.of(
+        HttpStatus.BAD_REQUEST.value(),
+        "올바르지 않은 이메일 형식입니다.",
+        ex.getMessage(),
+        request.getRequestURI()
+    );
+
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
+  }
+
   @ExceptionHandler(Exception.class)
   public ResponseEntity<ErrorResponse> handleGlobalException(Exception ex,
       HttpServletRequest request) {
@@ -82,4 +144,6 @@ public class GlobalExceptionHandler {
         .body(ErrorResponse.of(500, "서버 내부에서 오류가 발생하였습니다.", ex.getMessage(),
             request.getRequestURI()));
   }
+
+
 }

--- a/src/main/java/com/rocket/commons/exception/exceptions/InvalidEmailFormatException.java
+++ b/src/main/java/com/rocket/commons/exception/exceptions/InvalidEmailFormatException.java
@@ -1,0 +1,9 @@
+package com.rocket.commons.exception.exceptions;
+
+public class InvalidEmailFormatException extends RuntimeException {
+
+  public InvalidEmailFormatException(String message) {
+    super(message);
+  }
+
+}

--- a/src/main/java/com/rocket/commons/security/CustomUserDetails.java
+++ b/src/main/java/com/rocket/commons/security/CustomUserDetails.java
@@ -21,4 +21,5 @@ public record CustomUserDetails(Long id, String email, String password) implemen
   public String getUsername() {
     return email;
   }
+
 }

--- a/src/main/java/com/rocket/commons/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/rocket/commons/security/JwtAuthenticationFilter.java
@@ -19,7 +19,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
   private final JwtProvider jwtProvider;
   private final JwtResolver jwtResolver;
-  //  private final CustomUserDetailsService userDetailsService;
   private final AuthenticationManager authenticationManager;
   private final RefreshTokenStore redis;
 

--- a/src/main/java/com/rocket/commons/security/JwtProvider.java
+++ b/src/main/java/com/rocket/commons/security/JwtProvider.java
@@ -24,10 +24,16 @@ public class JwtProvider {
   }
 
   public String createAccessToken(String email) {
+    if (isInvalidToken(email)) {
+      return null;
+    }
     return createToken(email, accessTokenValidTime, "access");
   }
 
   public String createRefreshToken(String email) {
+    if (isInvalidToken(email)) {
+      return null;
+    }
     return createToken(email, refreshTokenValidTime, "refresh");
   }
 
@@ -46,6 +52,9 @@ public class JwtProvider {
   }
 
   public Boolean isRefreshTokenValid(String token) {
+    if (isInvalidToken(token)) {
+      return false;
+    }
     try {
       String type = Jwts.parser()
           .verifyWith(secretKey)
@@ -60,6 +69,9 @@ public class JwtProvider {
   }
 
   public Boolean isAccessTokenValid(String token) {
+    if (isInvalidToken(token)) {
+      return false;
+    }
     try {
       String type = Jwts.parser()
           .verifyWith(secretKey)
@@ -74,6 +86,9 @@ public class JwtProvider {
   }
 
   public boolean isExpired(String token) {
+    if (isInvalidToken(token)) {
+      return false;
+    }
     try {
       Jwts.parser()
           .verifyWith(secretKey)
@@ -92,18 +107,29 @@ public class JwtProvider {
    * 토큰에서 이메일(subject) 추출
    */
   public String getEmail(String token) {
-    return Jwts.parser()
-        .verifyWith(secretKey)
-        .build()
-        .parseSignedClaims(token)
-        .getPayload()
-        .get("sub", String.class);
+    if (isInvalidToken(token)) {
+      return null;
+    }
+    try {
+      return Jwts.parser()
+          .verifyWith(secretKey)
+          .build()
+          .parseSignedClaims(token)
+          .getPayload()
+          .get("sub", String.class);
+    } catch (JwtException e) {
+      return null;
+    }
+
   }
 
   /**
    * 토큰 유효성 검사
    */
   public boolean validateToken(String token) {
+    if (isInvalidToken(token)) {
+      return false;
+    }
     try {
       Jwts.parser()
           .verifyWith(secretKey)
@@ -113,6 +139,10 @@ public class JwtProvider {
     } catch (JwtException | IllegalArgumentException e) {
       return false;
     }
+  }
+
+  private boolean isInvalidToken(String token) {
+    return token == null || token.isBlank();
   }
 
 

--- a/src/main/java/com/rocket/domains/auth/application/service/AuthServiceImpl.java
+++ b/src/main/java/com/rocket/domains/auth/application/service/AuthServiceImpl.java
@@ -1,6 +1,7 @@
 package com.rocket.domains.auth.application.service;
 
 import com.rocket.commons.exception.exceptions.DuplicateEmailException;
+import com.rocket.commons.exception.exceptions.InvalidEmailFormatException;
 import com.rocket.commons.exception.exceptions.InvalidTokenException;
 import com.rocket.commons.exception.exceptions.LoginFailedException;
 import com.rocket.commons.security.JwtProvider;
@@ -152,6 +153,9 @@ public class AuthServiceImpl implements AuthService {
 
   @Override
   public void existsByEmail(String email) {
+    if (!email.matches("^[\\w.%+-]+@[\\w.-]+\\.[a-zA-Z]{2,6}$")) {
+      throw new InvalidEmailFormatException(email);
+    }
     if (userFacade.existsByEmail(email)) { // true -> 중복으로 예외 처리
       throw new DuplicateEmailException(email);
     }

--- a/src/test/java/com/rocket/RocketApplicationTests.java
+++ b/src/test/java/com/rocket/RocketApplicationTests.java
@@ -2,8 +2,10 @@ package com.rocket;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class RocketApplicationTests {
 
   @Test

--- a/src/test/java/com/rocket/commons/security/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/rocket/commons/security/JwtAuthenticationFilterTest.java
@@ -1,0 +1,285 @@
+package com.rocket.commons.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.rocket.domains.auth.domain.repository.RefreshTokenStore;
+import jakarta.servlet.FilterChain;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
+
+class JwtAuthenticationFilterTest {
+
+  @InjectMocks
+  private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+  @Mock
+  private JwtProvider jwtProvider;
+  @Mock
+  private JwtResolver jwtResolver;
+  @Mock
+  private AuthenticationManager authenticationManager;
+  @Mock
+  private RefreshTokenStore refreshTokenStore;
+  @Mock
+  private FilterChain filterChain;
+
+  private final String email = "test@rocket.com";
+  private final String accessToken = "validAccessToken";
+  private final String refreshToken = "validRefreshToken";
+  private final String newAccessToken = "newAccessToken";
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+    jwtAuthenticationFilter = new JwtAuthenticationFilter(jwtProvider, jwtResolver,
+        authenticationManager, refreshTokenStore);
+  }
+
+  @AfterEach
+  void tearDown() {
+    SecurityContextHolder.clearContext();
+  }
+
+
+  @Test
+  @DisplayName("유효한 AccessToken이 있을 경우 인증이 성공해야 한다.")
+  void validAccessTokenShouldAuthenticate() throws Exception {
+    // given
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.addHeader("Authorization", "Bearer " + accessToken);
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    when(jwtResolver.resolveAccessToken(anyString())).thenReturn(accessToken);
+    when(jwtProvider.validateToken(accessToken)).thenReturn(true);
+    when(jwtProvider.getEmail(accessToken)).thenReturn(email);
+
+    Authentication auth = mock(Authentication.class);
+    when(authenticationManager.authenticate(any())).thenReturn(auth);
+
+    // when
+    jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+    // then
+    verify(authenticationManager).authenticate(any(PreAuthenticatedAuthenticationToken.class));
+    verify(filterChain).doFilter(request, response);
+  }
+
+  @Test
+  @DisplayName("AccessToken이 만료되고 유효한 RefreshToken이 존재하면 새로운 AccessToken이 발급된다.")
+  void expiredAccessTokenWithValidRefreshTokenIssuesNewAccessToken() throws Exception {
+    // given
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.addHeader("Authorization", "Bearer expiredToken");
+    request.addHeader("X-Refresh-Token", refreshToken);
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    when(jwtResolver.resolveAccessToken(anyString())).thenReturn("expiredToken");
+    when(jwtProvider.validateToken("expiredToken")).thenReturn(false);
+    when(jwtProvider.isExpired("expiredToken")).thenReturn(true);
+
+    when(jwtResolver.resolveRefreshToken(anyString())).thenReturn(refreshToken);
+    when(jwtProvider.validateToken(refreshToken)).thenReturn(true);
+    when(jwtProvider.isRefreshTokenValid(refreshToken)).thenReturn(true);
+    when(jwtProvider.getEmail(refreshToken)).thenReturn(email);
+    when(refreshTokenStore.get(email)).thenReturn(refreshToken);
+    when(jwtProvider.createAccessToken(email)).thenReturn(newAccessToken);
+
+    Authentication auth = mock(Authentication.class);
+    when(authenticationManager.authenticate(any())).thenReturn(auth);
+
+    // when
+    jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+    // then
+    verify(jwtProvider).createAccessToken(email);
+    assertThat(response.getHeader("X-New-Access-Token")).isEqualTo(newAccessToken);
+    verify(filterChain).doFilter(request, response);
+  }
+
+  @Test
+  @DisplayName("AccessToken과 RefreshToken이 모두 유효하지 않은 경우 인증이 수행되지 않는다.")
+  void invalidTokensShouldNotAuthenticate() throws Exception {
+    // given
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.addHeader("Authorization", "Bearer invalidToken");
+    request.addHeader("X-Refresh-Token", "badRefreshToken");
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    when(jwtResolver.resolveAccessToken(anyString())).thenReturn("invalidToken");
+    when(jwtProvider.validateToken("invalidToken")).thenReturn(false);
+    when(jwtProvider.isExpired("invalidToken")).thenReturn(false);
+
+    // when
+    jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+    // then
+    verify(authenticationManager, never()).authenticate(any());
+    verify(filterChain).doFilter(request, response);
+    assertThat(response.getHeader("X-New-Access-Token")).isNull();
+  }
+
+  @DisplayName("Authorization 헤더가 없는 경우 필터가 통과한다")
+  @Test
+  void noAuthorizationHeader() throws Exception {
+    // given
+    MockHttpServletRequest request = new MockHttpServletRequest(); // Authorization 헤더 없음
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    when(jwtResolver.resolveAccessToken(null)).thenReturn(null);
+
+    // when
+    jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+    // then
+    verify(authenticationManager, never()).authenticate(any());
+    verify(filterChain).doFilter(request, response);
+  }
+
+  @DisplayName("RefreshToken이 Redis 값과 다르면 재발급되지 않는다")
+  @Test
+  void refreshTokenMismatchWithRedis() throws Exception {
+    // given
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.addHeader("Authorization", "Bearer expiredToken");
+    request.addHeader("X-Refresh-Token", refreshToken);
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    when(jwtResolver.resolveAccessToken(anyString())).thenReturn("expiredToken");
+    when(jwtProvider.validateToken("expiredToken")).thenReturn(false);
+    when(jwtProvider.isExpired("expiredToken")).thenReturn(true);
+
+    when(jwtResolver.resolveRefreshToken(anyString())).thenReturn(refreshToken);
+    when(jwtProvider.validateToken(refreshToken)).thenReturn(true);
+    when(jwtProvider.isRefreshTokenValid(refreshToken)).thenReturn(true);
+    when(jwtProvider.getEmail(refreshToken)).thenReturn(email);
+    when(refreshTokenStore.get(email)).thenReturn("differentToken");
+
+    // when
+    jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+    // then
+    verify(jwtProvider, never()).createAccessToken(any());
+    verify(authenticationManager, never()).authenticate(any());
+    assertThat(response.getHeader("X-New-Access-Token")).isNull();
+  }
+
+  @DisplayName("AccessToken이 만료됐지만 RefreshToken이 없으면 인증되지 않는다")
+  @Test
+  void expiredAccessTokenWithoutRefreshToken() throws Exception {
+    // given
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.addHeader("Authorization", "Bearer expiredToken");
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    when(jwtResolver.resolveAccessToken(anyString())).thenReturn("expiredToken");
+    when(jwtProvider.validateToken("expiredToken")).thenReturn(false);
+    when(jwtProvider.isExpired("expiredToken")).thenReturn(true);
+    when(jwtResolver.resolveRefreshToken(null)).thenReturn(null);
+
+    // when
+    jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+    // then
+    verify(authenticationManager, never()).authenticate(any());
+    assertThat(response.getHeader("X-New-Access-Token")).isNull();
+  }
+
+  @DisplayName("RefreshToken이 존재하지만 유효하지 않으면 인증되지 않는다")
+  @Test
+  void invalidRefreshTokenShouldNotAuthenticate() throws Exception {
+    // given
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.addHeader("Authorization", "Bearer expiredToken");
+    request.addHeader("X-Refresh-Token", refreshToken);
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    when(jwtResolver.resolveAccessToken(anyString())).thenReturn("expiredToken");
+    when(jwtProvider.validateToken("expiredToken")).thenReturn(false);
+    when(jwtProvider.isExpired("expiredToken")).thenReturn(true);
+
+    when(jwtResolver.resolveRefreshToken(anyString())).thenReturn(refreshToken);
+    when(jwtProvider.validateToken(refreshToken)).thenReturn(false);
+
+    // when
+    jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+    // then
+    verify(authenticationManager, never()).authenticate(any());
+    verify(jwtProvider, never()).createAccessToken(any());
+    assertThat(response.getHeader("X-New-Access-Token")).isNull();
+  }
+
+  @DisplayName("AccessToken이 유효하면 SecurityContextHolder에 인증 정보가 저장된다")
+  @Test
+  void authenticationIsSetInSecurityContextHolder() throws Exception {
+    // given
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.addHeader("Authorization", "Bearer " + accessToken);
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    when(jwtResolver.resolveAccessToken(anyString())).thenReturn(accessToken);
+    when(jwtProvider.validateToken(accessToken)).thenReturn(true);
+    when(jwtProvider.getEmail(accessToken)).thenReturn(email);
+
+    Authentication mockAuth = mock(Authentication.class);
+    when(authenticationManager.authenticate(any())).thenReturn(mockAuth);
+
+    // 👉 테스트 전 기존 인증 정보 초기화
+    SecurityContextHolder.clearContext();
+
+    // when
+    jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+    // then
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+    assertThat(authentication).isNotNull();
+    assertThat(authentication).isEqualTo(mockAuth);  // mocking된 Authentication 객체와 일치
+    verify(filterChain).doFilter(request, response);
+  }
+
+  @DisplayName("AccessToken이 유효하지 않으면 SecurityContextHolder에 인증 정보가 저장되지 않는다")
+  @Test
+  void authenticationIsNotSetWhenTokenInvalid() throws Exception {
+    // given
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.addHeader("Authorization", "Bearer invalidToken");
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    when(jwtResolver.resolveAccessToken(anyString())).thenReturn("invalidToken");
+    when(jwtProvider.validateToken("invalidToken")).thenReturn(false);
+    when(jwtProvider.isExpired("invalidToken")).thenReturn(false); // 단순히 유효하지 않음
+
+    // 👉 테스트 전 인증 정보 초기화
+    SecurityContextHolder.clearContext();
+
+    // when
+    jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+    // then
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    assertThat(authentication).isNull();
+
+    verify(authenticationManager, never()).authenticate(any());
+    verify(filterChain).doFilter(request, response);
+  }
+
+
+}

--- a/src/test/java/com/rocket/commons/security/JwtProviderUnitTest.java
+++ b/src/test/java/com/rocket/commons/security/JwtProviderUnitTest.java
@@ -1,0 +1,95 @@
+package com.rocket.commons.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class JwtProviderUnitTest {
+
+  private JwtProvider jwtProvider;
+  private final String base64Secret = "dGVzdC1zZWNyZXQta2V5LXRlc3Qtc2VjcmV0LXRlc3Qtc2VjcmV0LXRlc3Qtc2VjcmV0LXRlc3Q=";
+  private final String email = "test@rocket.com";
+
+  @BeforeEach
+  void setUp() {
+    jwtProvider = new JwtProvider(base64Secret);
+  }
+
+  @Test
+  @DisplayName("AccessToken 생성 및 유효성 검증")
+  void createAndValidateAccessToken() {
+    String token = jwtProvider.createAccessToken(email);
+
+    assertThat(jwtProvider.validateToken(token)).isTrue();
+    assertThat(jwtProvider.isAccessTokenValid(token)).isTrue();
+    assertThat(jwtProvider.isRefreshTokenValid(token)).isFalse();
+    assertThat(jwtProvider.getEmail(token)).isEqualTo(email);
+  }
+
+  @Test
+  @DisplayName("RefreshToken 생성 및 유효성 검증")
+  void createAndValidateRefreshToken() {
+    String token = jwtProvider.createRefreshToken(email);
+
+    assertThat(jwtProvider.validateToken(token)).isTrue();
+    assertThat(jwtProvider.isAccessTokenValid(token)).isFalse();
+    assertThat(jwtProvider.isRefreshTokenValid(token)).isTrue();
+    assertThat(jwtProvider.getEmail(token)).isEqualTo(email);
+  }
+
+  @Test
+  @DisplayName("만료된 토큰 처리")
+  void expiredToken() throws InterruptedException {
+    String token = jwtProvider.createToken(email, 1000L, "access");
+    Thread.sleep(1100);
+    assertThat(jwtProvider.isExpired(token)).isTrue();
+    assertThat(jwtProvider.validateToken(token)).isFalse();
+  }
+
+  @Test
+  @DisplayName("잘못된 형식의 토큰 처리")
+  void invalidToken() {
+    String invalidToken = "abc.def.ghi";
+    assertThat(jwtProvider.validateToken(invalidToken)).isFalse();
+    assertThat(jwtProvider.isAccessTokenValid(invalidToken)).isFalse();
+    assertThat(jwtProvider.isRefreshTokenValid(invalidToken)).isFalse();
+    assertThat(jwtProvider.isExpired(invalidToken)).isFalse();
+  }
+
+  @Test
+  @DisplayName("tokenType 클레임이 없을 경우 false 반환")
+  void tokenWithoutTokenType() {
+    String token = Jwts.builder()
+        .claim("sub", email)
+        .signWith(Keys.hmacShaKeyFor("fakefakefakefakefakefakefakefake".getBytes()))
+        .compact();
+
+    assertThat(jwtProvider.isAccessTokenValid(token)).isFalse();
+    assertThat(jwtProvider.isRefreshTokenValid(token)).isFalse();
+  }
+
+  @Test
+  @DisplayName("sub 클레임이 없을 경우 null 반환")
+  void getEmailWithoutSub() {
+    String token = Jwts.builder()
+        .claim("tokenType", "access")
+        .signWith(Keys.hmacShaKeyFor("fakefakefakefakefakefakefakefake".getBytes()))
+        .compact();
+
+    assertThat(jwtProvider.getEmail(token)).isNull();
+  }
+
+  @Test
+  @DisplayName("빈 토큰 및 null 토큰은 모두 invalid")
+  void nullOrEmptyToken() {
+    assertThat(jwtProvider.validateToken(null)).isFalse();
+    assertThat(jwtProvider.validateToken("")).isFalse();
+    assertThat(jwtProvider.isAccessTokenValid(null)).isFalse();
+    assertThat(jwtProvider.isRefreshTokenValid("")).isFalse();
+    assertThat(jwtProvider.isExpired(null)).isFalse();
+  }
+}

--- a/src/test/java/com/rocket/commons/security/JwtResolverUnitTest.java
+++ b/src/test/java/com/rocket/commons/security/JwtResolverUnitTest.java
@@ -1,0 +1,39 @@
+package com.rocket.commons.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class JwtResolverUnitTest {
+
+  private final JwtResolver jwtResolver = new JwtResolver();
+
+  @Test
+  @DisplayName("AccessToken에서 'Bearer ' 접두어를 제거하고 토큰만 반환한다.")
+  void resolveAccessToken_withBearerPrefix_returnsToken() {
+    String bearerToken = "Bearer abc.def.ghi";
+    String result = jwtResolver.resolveAccessToken(bearerToken);
+
+    assertThat(result).isEqualTo("abc.def.ghi");
+  }
+
+  @Test
+  @DisplayName("RefreshToken에서 'Bearer ' 접두어를 제거하고 토큰만 반환한다.")
+  void resolveRefreshToken_withBearerPrefix_returnsToken() {
+    String bearerToken = "Bearer xyz.123.456";
+    String result = jwtResolver.resolveRefreshToken(bearerToken);
+
+    assertThat(result).isEqualTo("xyz.123.456");
+  }
+
+  @Test
+  @DisplayName("접두어가 없거나 null이면 null을 반환한다.")
+  void resolveToken_whenMissingBearer_returnsNull() {
+    assertThat(jwtResolver.resolveAccessToken(null)).isNull();
+    assertThat(jwtResolver.resolveAccessToken("abc.def.ghi")).isNull();
+    assertThat(jwtResolver.resolveRefreshToken("")).isNull();
+  }
+
+
+}

--- a/src/test/java/com/rocket/commons/security/service/CustomUserDetailsServiceUnitTest.java
+++ b/src/test/java/com/rocket/commons/security/service/CustomUserDetailsServiceUnitTest.java
@@ -1,0 +1,85 @@
+package com.rocket.commons.security.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.rocket.commons.security.CustomUserDetails;
+import com.rocket.domains.auth.domain.entity.AuthUser;
+import com.rocket.domains.auth.domain.repository.AuthUserReader;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+
+class CustomUserDetailsServiceUnitTest {
+
+  private AuthUserReader authUserReader;
+  private CustomUserDetailsService customUserDetailsService;
+
+  @BeforeEach
+  void setUp() {
+    authUserReader = mock(AuthUserReader.class);
+    customUserDetailsService = new CustomUserDetailsService(authUserReader);
+  }
+
+  @Test
+  @DisplayName("이메일로 사용자 정보를 성공적으로 로드할 수 있다.")
+  void loadUserByUsernameSuccess() {
+    // given
+    String email = "test@rocket.com";
+    String password = "encodedPassword";
+    Long userId = 1L;
+
+    AuthUser authUser = new AuthUser(userId, email, password);
+    when(authUserReader.getAuthUserByEmail(email)).thenReturn(Optional.of(authUser));
+
+    // when
+    UserDetails userDetails = customUserDetailsService.loadUserByUsername(email);
+
+    // then
+    assertThat(userDetails).isInstanceOf(CustomUserDetails.class);
+    CustomUserDetails customUserDetails = (CustomUserDetails) userDetails;
+    assertThat(customUserDetails.email()).isEqualTo(email);
+    assertThat(customUserDetails.getPassword()).isEqualTo(password);
+    assertThat(customUserDetails.id()).isEqualTo(userId);
+  }
+
+  @Test
+  @DisplayName("사용자를 찾을 수 없을 경우 UsernameNotFoundException 예외를 던진다.")
+  void loadUserByUsernameThrowsException() {
+    // given
+    String email = "notfound@rocket.com";
+    when(authUserReader.getAuthUserByEmail(email)).thenReturn(Optional.empty());
+
+    // expect
+    assertThrows(UsernameNotFoundException.class, () ->
+        customUserDetailsService.loadUserByUsername(email));
+  }
+
+  @DisplayName("null 이메일을 전달하면 UsernameNotFoundException을 던진다")
+  @Test
+  void loadUserByUsernameWithNullEmail() {
+    assertThrows(UsernameNotFoundException.class, () -> {
+      customUserDetailsService.loadUserByUsername(null);
+    });
+  }
+
+  @DisplayName("AuthUser의 필드가 일부 null이더라도 CustomUserDetails는 생성된다")
+  @Test
+  void loadUserByUsernameWithIncompleteAuthUser() {
+    String email = "incomplete@rocket.com";
+    AuthUser authUser = new AuthUser(null, email, null); // ID, password가 null
+    when(authUserReader.getAuthUserByEmail(email)).thenReturn(Optional.of(authUser));
+
+    UserDetails userDetails = customUserDetailsService.loadUserByUsername(email);
+
+    assertThat(userDetails.getUsername()).isEqualTo(email);
+    assertThat(userDetails.getPassword()).isNull();
+  }
+
+
+}

--- a/src/test/java/com/rocket/domains/auth/application/service/AuthServiceImplUnitTest.java
+++ b/src/test/java/com/rocket/domains/auth/application/service/AuthServiceImplUnitTest.java
@@ -1,0 +1,253 @@
+package com.rocket.domains.auth.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.rocket.commons.exception.exceptions.DuplicateEmailException;
+import com.rocket.commons.exception.exceptions.InvalidTokenException;
+import com.rocket.commons.exception.exceptions.LoginFailedException;
+import com.rocket.commons.security.JwtProvider;
+import com.rocket.commons.security.JwtResolver;
+import com.rocket.domains.auth.application.dto.response.TokenResponse;
+import com.rocket.domains.auth.domain.repository.RefreshTokenStore;
+import com.rocket.domains.user.application.dto.request.AddressRequest;
+import com.rocket.domains.user.application.dto.request.UserRegisterRequest;
+import com.rocket.domains.user.domain.entity.Address;
+import com.rocket.domains.user.domain.entity.User;
+import com.rocket.domains.user.domain.enums.Gender;
+import com.rocket.domains.user.domain.facade.UserFacade;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+class AuthServiceImplUnitTest {
+
+  private UserFacade userFacade;
+  private JwtProvider jwtProvider;
+  private JwtResolver jwtResolver;
+  private PasswordEncoder passwordEncoder;
+  private RefreshTokenStore refreshTokenStore;
+
+  private AuthServiceImpl authService;
+
+  @BeforeEach
+  void setUp() {
+    userFacade = mock(UserFacade.class);
+    jwtProvider = mock(JwtProvider.class);
+    jwtResolver = mock(JwtResolver.class);
+    passwordEncoder = mock(PasswordEncoder.class);
+    refreshTokenStore = mock(RefreshTokenStore.class);
+
+    authService = new AuthServiceImpl(userFacade, jwtProvider, jwtResolver, passwordEncoder,
+        refreshTokenStore);
+  }
+
+  @Test
+  @DisplayName("회원가입에 성공하면 access, refresh 토큰이 반환된다.")
+  void registerSuccess() {
+    // given
+    UserRegisterRequest dto = new UserRegisterRequest(
+        "test@rocket.com", "password", "25",
+        Gender.MALE, new AddressRequest("서울", "강남", "테헤란로", "12345"), "rocket"
+    );
+
+    User user = User.createWithIdForTest(1L, dto.email(), dto.password(), 25, Gender.MALE,
+        new Address("서울", "강남", "테헤란로", "12345"), dto.nickname());
+
+    when(userFacade.registerUser(dto)).thenReturn(user);
+    when(jwtProvider.createAccessToken(dto.email())).thenReturn("accessToken");
+    when(jwtProvider.createRefreshToken(dto.email())).thenReturn("refreshToken");
+
+    // when
+    TokenResponse result = authService.register(dto);
+
+    // then
+    assertThat(result.accessToken()).isEqualTo("accessToken");
+    assertThat(result.refreshToken()).isEqualTo("refreshToken");
+    assertThat(result.message()).contains(dto.email());
+    verify(refreshTokenStore).save(eq(dto.email()), anyString());
+  }
+
+  @Test
+  @DisplayName("이메일 또는 비밀번호가 틀리면 LoginFailedException이 발생한다.")
+  void loginFail() {
+    String email = "test@rocket.com";
+    String password = "wrong";
+
+    when(userFacade.findUserByEmail(email)).thenReturn(Optional.empty());
+
+    assertThrows(LoginFailedException.class, () -> authService.login(email, password));
+  }
+
+  @Test
+  @DisplayName("유효하지 않은 RefreshToken으로 accessReissue를 요청하면 예외가 발생한다.")
+  void accessReissueInvalidToken() {
+    when(jwtProvider.validateToken("badToken")).thenReturn(false);
+
+    assertThrows(InvalidTokenException.class, () -> authService.accessReissue("badToken"));
+  }
+
+  @Test
+  @DisplayName("이메일 중복 체크 시 이미 존재하면 DuplicateEmailException 발생한다.")
+  void existsByEmailThrowsException() {
+    String email = "test@rocket.com";
+    when(userFacade.existsByEmail(email)).thenReturn(true);
+
+    assertThrows(DuplicateEmailException.class, () -> authService.existsByEmail(email));
+  }
+
+  @Test
+  @DisplayName("login() - refreshToken 재발급 조건 분기 테스트")
+  void loginShouldIssueNewRefreshTokenWhenTtlLow() {
+    // given
+    String email = "test@rocket.com";
+    String rawPassword = "password";
+    String encodedPassword = "encodedPassword";
+    String accessToken = "accessToken";
+    String newRefreshToken = "newRefreshToken";
+
+    User user = User.createWithIdForTest(1L, email, encodedPassword, 25, Gender.MALE,
+        new Address("서울", "강남", "테헤란로", "12345"), "nickname");
+
+    when(userFacade.findUserByEmail(email)).thenReturn(Optional.of(user));
+    when(passwordEncoder.matches(rawPassword, encodedPassword)).thenReturn(true);
+    when(jwtProvider.createAccessToken(email)).thenReturn(accessToken);
+    when(refreshTokenStore.getExpire(email)).thenReturn(100L); // 100초 남음
+    when(jwtProvider.createRefreshToken(email)).thenReturn(newRefreshToken);
+
+    // when
+    TokenResponse response = authService.login(email, rawPassword);
+
+    // then
+    assertThat(response.accessToken()).isEqualTo(accessToken);
+    assertThat(response.refreshToken()).isEqualTo(newRefreshToken);
+    verify(refreshTokenStore).save(email, newRefreshToken);
+  }
+
+  @Test
+  @DisplayName("accessReissue() - refreshToken은 유효하지만 redis 값과 일치하지 않으면 예외")
+  void accessReissueFailsWhenRefreshTokenMismatch() {
+    // given
+    String refreshToken = "clientToken";
+    String storedToken = "serverToken";
+    String email = "test@rocket.com";
+
+    when(jwtProvider.validateToken(refreshToken)).thenReturn(true);
+    when(jwtProvider.isRefreshTokenValid(refreshToken)).thenReturn(true);
+    when(jwtProvider.getEmail(refreshToken)).thenReturn(email);
+    when(refreshTokenStore.get(email)).thenReturn(storedToken);
+
+    // then
+    assertThrows(InvalidTokenException.class, () -> authService.accessReissue(refreshToken));
+  }
+
+  @Test
+  @DisplayName("logout() - 유효하지 않은 AccessToken 입력 시 예외 발생")
+  void logoutFailsForInvalidToken() {
+    // given
+    String token = "invalidToken";
+    when(jwtProvider.isAccessTokenValid(token)).thenReturn(false);
+
+    // then
+    assertThrows(InvalidTokenException.class, () -> authService.logout(token));
+  }
+
+  @Test
+  @DisplayName("authenticate() - 비밀번호가 일치하지 않으면 예외 발생")
+  void authenticateFailsOnWrongPassword() {
+    // given
+    String email = "test@rocket.com";
+    String correctPassword = "encodedPassword";
+    String wrongPassword = "wrongPassword";
+
+    User user = User.createWithIdForTest(1L, email, correctPassword, 25, Gender.MALE,
+        new Address("서울", "강남", "테헤란로", "12345"), "nickname");
+
+    when(userFacade.findUserByEmail(email)).thenReturn(Optional.of(user));
+    when(passwordEncoder.matches(wrongPassword, correctPassword)).thenReturn(false);
+
+    // then
+    assertThrows(LoginFailedException.class, () -> authService.authenticate(email, wrongPassword));
+  }
+
+  @Test
+  @DisplayName("authenticate() - 이메일이 존재하지 않으면 dummyPassword 비교 후 예외 발생")
+  void authenticateFailsWhenEmailNotFound() {
+    // given
+    String email = "nonexistent@rocket.com";
+    String rawPassword = "password";
+
+    when(userFacade.findUserByEmail(email)).thenReturn(Optional.empty());
+
+    // then
+    assertThrows(LoginFailedException.class, () ->
+        authService.authenticate(email, rawPassword)
+    );
+
+    // dummyPassword 비교가 호출되었는지 검증
+    verify(passwordEncoder).matches(eq(rawPassword), anyString());
+  }
+
+  @Test
+  @DisplayName("refreshReissue() - Redis TTL이 충분하면 RefreshToken을 재발급하지 않는다.")
+  void refreshReissueWithoutRenewal() {
+    // given
+    String email = "test@rocket.com";
+    String accessToken = "accessToken";
+    String existingRefreshToken = "existingRefreshToken";
+
+    when(refreshTokenStore.get(email)).thenReturn(existingRefreshToken);
+    when(jwtProvider.validateToken(existingRefreshToken)).thenReturn(true);
+    when(jwtProvider.isRefreshTokenValid(existingRefreshToken)).thenReturn(true);
+    when(jwtProvider.createAccessToken(email)).thenReturn(accessToken);
+    when(refreshTokenStore.getExpire(email)).thenReturn(60 * 60 * 24 * 3L); // 3일 TTL
+
+    // when
+    TokenResponse response = authService.refreshReissue(email,
+        false); // shouldRefreshToken == false
+
+    // then
+    assertThat(response.accessToken()).isEqualTo(accessToken);
+    assertThat(response.refreshToken()).isEqualTo(existingRefreshToken);
+    verify(refreshTokenStore, never()).save(any(), any());
+  }
+
+  @Test
+  @DisplayName("register() - 회원가입 시 RefreshToken이 Redis에 저장된다.")
+  void registerShouldSaveRefreshTokenInRedis() {
+    // given
+    String email = "test@rocket.com";
+    String accessToken = "accessToken";
+    String refreshToken = "refreshToken";
+
+    AddressRequest address = new AddressRequest("서울", "강남", "테헤란로", "12345");
+    UserRegisterRequest request = new UserRegisterRequest(
+        email, "password", "25", Gender.MALE, address, "nickname");
+
+    User savedUser = User.createWithIdForTest(1L, email, "encodedPassword", 25,
+        Gender.MALE, new Address("서울", "강남", "테헤란로", "12345"), "nickname");
+
+    when(userFacade.registerUser(request)).thenReturn(savedUser);
+    when(jwtProvider.createAccessToken(email)).thenReturn(accessToken);
+    when(jwtProvider.createRefreshToken(email)).thenReturn(refreshToken);
+
+    // when
+    TokenResponse response = authService.register(request);
+
+    // then
+    assertThat(response.accessToken()).isEqualTo(accessToken);
+    assertThat(response.refreshToken()).isEqualTo(refreshToken);
+    verify(refreshTokenStore).save(email, refreshToken);
+  }
+
+
+}

--- a/src/test/java/com/rocket/domains/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/com/rocket/domains/auth/presentation/AuthControllerTest.java
@@ -1,0 +1,284 @@
+package com.rocket.domains.auth.presentation;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rocket.commons.exception.exceptions.InvalidTokenException;
+import com.rocket.commons.exception.exceptions.LoginFailedException;
+import com.rocket.commons.security.JwtProvider;
+import com.rocket.commons.security.JwtResolver;
+import com.rocket.domains.auth.application.dto.response.TokenResponse;
+import com.rocket.domains.auth.domain.service.AuthService;
+import com.rocket.domains.user.application.dto.request.LoginRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+@WebMvcTest(AuthController.class)
+@Import(AuthControllerTest.MockConfig.class)
+class AuthControllerTest {
+
+  @TestConfiguration
+  static class SecurityTestConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+      return http
+          .csrf(AbstractHttpConfigurer::disable) // <-- CSRF 비활성화
+          .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+          .build();
+    }
+  }
+
+  @Autowired
+  private MockMvc mockMvc;
+  @Autowired
+  private AuthService authService;
+  @Autowired
+  private JwtProvider jwtProvider;
+  @Autowired
+  private JwtResolver jwtResolver;
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  @TestConfiguration
+  static class MockConfig {
+
+    @Bean
+    public AuthService authService() {
+      return mock(AuthService.class);
+    }
+
+    @Bean
+    public JwtProvider jwtProvider() {
+      return mock(JwtProvider.class);
+    }
+
+    @Bean
+    public JwtResolver jwtResolver() {
+      return mock(JwtResolver.class);
+    }
+  }
+
+  @BeforeEach
+  void resetMocks() {
+    reset(authService, jwtProvider, jwtResolver);
+  }
+
+  @Test
+  @DisplayName("로그인 성공 시 200 OK와 토큰 정보 반환")
+  void loginSuccess() throws Exception {
+    LoginRequest loginRequest = new LoginRequest("test@rocket.com", "password123");
+    TokenResponse tokenResponse = new TokenResponse("access-token", "refresh-token",
+        "로그인에 성공하였습니다");
+
+    when(authService.login(any(), any())).thenReturn(tokenResponse);
+
+    mockMvc.perform(MockMvcRequestBuilders.post("/auth/login")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(loginRequest)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.accessToken").value("access-token"))
+        .andExpect(jsonPath("$.refreshToken").value("refresh-token"))
+        .andExpect(jsonPath("$.message").value("로그인에 성공하였습니다"));
+  }
+
+  @Test
+  @DisplayName("로그인 실패 시 401 Unauthorized 응답")
+  void loginFail() throws Exception {
+    LoginRequest loginRequest = new LoginRequest("test@rocket.com", "wrongpassword");
+
+    when(authService.login(any(), any())).thenThrow(new LoginFailedException("로그인 실패"));
+
+    mockMvc.perform(MockMvcRequestBuilders.post("/auth/login")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(loginRequest)))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.error").value("인증이 실패하였습니다."));
+  }
+
+  @Test
+  @DisplayName("로그아웃 성공 시 204 No Content")
+  void logoutSuccess() throws Exception {
+    when(jwtResolver.resolveRefreshToken(anyString())).thenReturn("access-token");
+
+    mockMvc.perform(MockMvcRequestBuilders.post("/auth/logout")
+            .header("Authorization", "Bearer access-token"))
+        .andExpect(status().isNoContent());
+  }
+
+  @Test
+  @DisplayName("로그아웃 실패 - 유효하지 않은 토큰이면 401 응답")
+  void logoutFail() throws Exception {
+    when(jwtResolver.resolveRefreshToken(anyString())).thenReturn("invalid-token");
+    doThrow(new InvalidTokenException("유효하지 않은 토큰입니다.")).when(authService).logout("invalid-token");
+
+    mockMvc.perform(MockMvcRequestBuilders.post("/auth/logout")
+            .header("Authorization", "Bearer invalid-token"))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.error").value("유효하지 않은 토큰입니다."));
+  }
+
+  @Test
+  @DisplayName("AccessToken 재발급 성공")
+  void accessReissueSuccess() throws Exception {
+    when(jwtResolver.resolveRefreshToken(anyString())).thenReturn("refresh-token");
+    when(authService.accessReissue("refresh-token"))
+        .thenReturn(new TokenResponse("new-access", "same-refresh", "AccessToken이 재발급되었습니다."));
+
+    mockMvc.perform(MockMvcRequestBuilders.post("/auth/access-reissue")
+            .header("X-Refresh-Token", "Bearer refresh-token"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.accessToken").value("new-access"));
+  }
+
+  @Test
+  @DisplayName("AccessToken 재발급 실패 - 잘못된 RefreshToken")
+  void accessReissueFail() throws Exception {
+    when(jwtResolver.resolveRefreshToken(anyString())).thenReturn("bad-refresh-token");
+    when(authService.accessReissue("bad-refresh-token"))
+        .thenThrow(new InvalidTokenException("유효하지 않은 RefreshToken입니다."));
+
+    mockMvc.perform(MockMvcRequestBuilders.post("/auth/access-reissue")
+            .header("X-Refresh-Token", "Bearer bad-refresh-token"))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.error").value("유효하지 않은 토큰입니다."));
+  }
+
+  @Test
+  @DisplayName("RefreshToken 재발급 포함 - 성공")
+  void refreshReissueSuccess() throws Exception {
+    when(jwtResolver.resolveAccessToken(anyString())).thenReturn("access-token");
+    when(jwtProvider.getEmail("access-token")).thenReturn("test@rocket.com");
+    when(authService.refreshReissue("test@rocket.com", true))
+        .thenReturn(new TokenResponse("new-access", "new-refresh", "AccessToken이 재발급되었습니다."));
+
+    mockMvc.perform(MockMvcRequestBuilders.post("/auth/refresh-reissue")
+            .header("Authorization", "Bearer access-token"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.accessToken").value("new-access"))
+        .andExpect(jsonPath("$.refreshToken").value("new-refresh"));
+  }
+
+  @Test
+  @DisplayName("로그인 시 이메일이 누락되면 400 Bad Request 반환")
+  void loginMissingEmail() throws Exception {
+    LoginRequest invalidRequest = new LoginRequest("", "password123");
+
+    mockMvc.perform(MockMvcRequestBuilders.post("/auth/login")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(invalidRequest)))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @DisplayName("로그아웃 시 Authorization 헤더가 없으면 400 또는 401 반환")
+  void logoutMissingAuthorizationHeader() throws Exception {
+    mockMvc.perform(MockMvcRequestBuilders.post("/auth/logout"))
+        .andExpect(status().is4xxClientError()); // 400 or 401 depending on handler
+  }
+
+  @Test
+  @DisplayName("RefreshToken 재발급 시 Authorization 헤더가 없으면 400 또는 401 반환")
+  void refreshReissueMissingHeader() throws Exception {
+    mockMvc.perform(MockMvcRequestBuilders.post("/auth/refresh-reissue"))
+        .andExpect(status().is4xxClientError());
+  }
+
+  @Test
+  @DisplayName("AccessToken을 RefreshToken 자리에 넣으면 401 Unauthorized")
+  void accessReissueWithAccessTokenInsteadOfRefreshToken() throws Exception {
+    when(jwtResolver.resolveRefreshToken(anyString())).thenReturn("access-token");
+    when(authService.accessReissue("access-token"))
+        .thenThrow(new InvalidTokenException("RefreshToken 타입이 아닙니다."));
+
+    mockMvc.perform(MockMvcRequestBuilders.post("/auth/access-reissue")
+            .header("X-Refresh-Token", "Bearer access-token"))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.error").value("유효하지 않은 토큰입니다."));
+  }
+
+  @Test
+  @DisplayName("Authorization 헤더에 'Bearer ' 접두사가 없으면 InvalidTokenException 발생")
+  void logoutMissingBearerPrefix() throws Exception {
+    String token = "access-token"; // Bearer 접두사 없음
+
+    when(jwtResolver.resolveRefreshToken(token))
+        .thenThrow(new InvalidTokenException("유효하지 않은 토큰입니다."));
+
+    mockMvc.perform(MockMvcRequestBuilders.post("/auth/logout")
+            .header("Authorization", token)) // Bearer 빠짐
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.error").value("유효하지 않은 토큰입니다."));
+  }
+
+  @Test
+  @DisplayName("Authorization 헤더에 잘못된 토큰 구조 전달 시 401")
+  void logoutWithMalformedToken() throws Exception {
+    String malformedToken = "not.a.jwt.token";
+
+    when(jwtResolver.resolveRefreshToken(malformedToken))
+        .thenThrow(new InvalidTokenException("유효하지 않은 토큰입니다."));
+
+    mockMvc.perform(MockMvcRequestBuilders.post("/auth/logout")
+            .header("Authorization", malformedToken))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.error").value("유효하지 않은 토큰입니다."));
+  }
+
+  @Test
+  @DisplayName("RefreshToken 재발급 - TTL 충분한 경우에도 정상 처리")
+  void refreshReissueWithValidTokenAndSufficientTTL() throws Exception {
+    String accessToken = "Bearer access-token";
+
+    when(jwtResolver.resolveAccessToken("Bearer access-token")).thenReturn("access-token");
+    when(jwtProvider.getEmail("access-token")).thenReturn("test@rocket.com");
+
+    TokenResponse response = new TokenResponse("access", "refresh", "갱신 성공");
+    when(authService.refreshReissue("test@rocket.com", true)).thenReturn(response);
+
+    mockMvc.perform(MockMvcRequestBuilders.post("/auth/refresh-reissue")
+            .header("Authorization", accessToken))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.accessToken").value("access"))
+        .andExpect(jsonPath("$.refreshToken").value("refresh"));
+  }
+
+  @Test
+  @DisplayName("로그인 요청에 request body가 없으면 400 Bad Request")
+  void loginWithNoRequestBody() throws Exception {
+    mockMvc.perform(MockMvcRequestBuilders.post("/auth/login")
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.error").value("요청 값이 올바르지 않습니다."));
+  }
+
+  @Test
+  @DisplayName("Content-Type 누락된 로그인 요청은 415 Unsupported Media Type")
+  void loginMissingContentType() throws Exception {
+    LoginRequest loginRequest = new LoginRequest("test@rocket.com", "password123");
+
+    mockMvc.perform(MockMvcRequestBuilders.post("/auth/login")
+            .content(objectMapper.writeValueAsString(loginRequest)))
+        .andExpect(status().isUnsupportedMediaType()); // 또는 BadRequest depending on config
+  }
+
+}

--- a/src/test/java/com/rocket/domains/auth/presentation/EmailCheckControllerTest.java
+++ b/src/test/java/com/rocket/domains/auth/presentation/EmailCheckControllerTest.java
@@ -1,0 +1,81 @@
+package com.rocket.domains.auth.presentation;
+
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.rocket.commons.exception.exceptions.InvalidEmailFormatException;
+import com.rocket.domains.auth.domain.service.AuthService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+@WebMvcTest(EmailCheckController.class)
+@Import(EmailCheckControllerTest.MockConfig.class)
+class EmailCheckControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+  @Autowired
+  private AuthService authService;
+
+
+  @TestConfiguration
+  static class SecurityTestConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+      return http
+          .csrf(AbstractHttpConfigurer::disable) // <-- CSRF 비활성화
+          .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+          .build();
+    }
+  }
+
+  @TestConfiguration
+  static class MockConfig {
+
+    @Bean
+    public AuthService authService() {
+      return mock(AuthService.class);
+    }
+  }
+
+  @Test
+  @DisplayName("이메일 중복 확인 성공 시 204 No Content")
+  void checkEmailSuccess() throws Exception {
+    doNothing().when(authService).existsByEmail("test@rocket.com");
+
+    mockMvc.perform(MockMvcRequestBuilders.get("/email/check")
+            .param("email", "test@rocket.com"))
+        .andExpect(status().isNoContent());
+  }
+
+  @Test
+  @DisplayName("이메일 파라미터가 없으면 400 Bad Request")
+  void checkEmailMissingParam() throws Exception {
+    mockMvc.perform(MockMvcRequestBuilders.get("/email/check"))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @DisplayName("이메일 형식이 잘못되면 400 Bad Request")
+  void checkInvalidEmailFormat() throws Exception {
+    doThrow(new InvalidEmailFormatException("invalid-email"))
+        .when(authService).existsByEmail("invalid-email");
+
+    mockMvc.perform(MockMvcRequestBuilders.get("/email/check")
+            .param("email", "invalid-email"))
+        .andExpect(status().isBadRequest());
+  }
+}

--- a/src/test/java/com/rocket/domains/auth/presentation/RegisterControllerTest.java
+++ b/src/test/java/com/rocket/domains/auth/presentation/RegisterControllerTest.java
@@ -1,0 +1,234 @@
+package com.rocket.domains.auth.presentation;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rocket.commons.exception.exceptions.DuplicateEmailException;
+import com.rocket.domains.auth.application.dto.response.TokenResponse;
+import com.rocket.domains.auth.domain.service.AuthService;
+import com.rocket.domains.user.application.dto.request.AddressRequest;
+import com.rocket.domains.user.application.dto.request.UserRegisterRequest;
+import com.rocket.domains.user.domain.enums.Gender;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(RegisterController.class)
+@Import(RegisterControllerTest.TestConfig.class)
+class RegisterControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+  @Autowired
+  private AuthService authService;
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @TestConfiguration
+  static class TestConfig {
+
+    @Bean
+    public AuthService authService() {
+      return mock(AuthService.class);
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+      return http.csrf(AbstractHttpConfigurer::disable)
+          .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+          .build();
+    }
+  }
+
+  private UserRegisterRequest createValidRequest() {
+    return new UserRegisterRequest(
+        "test@rocket.com",
+        "123456",
+        "25",
+        Gender.MALE,
+        new AddressRequest("서울시", "강남구", "역삼로 123", "06234"),
+        "test_nickname"
+    );
+  }
+
+  @Test
+  @DisplayName("회원가입 성공 시 200 OK")
+  void registerSuccess() throws Exception {
+    UserRegisterRequest request = createValidRequest();
+    TokenResponse response = new TokenResponse("access-token", "refresh-token",
+        "test@rocket.com 계정 생성이 성공하였습니다.");
+
+    when(authService.register(any(UserRegisterRequest.class))).thenReturn(response);
+
+    mockMvc.perform(post("/register")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.accessToken").value("access-token"))
+        .andExpect(jsonPath("$.refreshToken").value("refresh-token"))
+        .andExpect(jsonPath("$.message").value("test@rocket.com 계정 생성이 성공하였습니다."));
+  }
+
+  @Test
+  @DisplayName("유효하지 않은 이메일 형식으로 회원가입 요청 시 400 Bad Request")
+  void registerInvalidEmail() throws Exception {
+    UserRegisterRequest request = new UserRegisterRequest(
+        "invalid-email",
+        "123456",
+        "25",
+        Gender.MALE,
+        new AddressRequest("서울시", "강남구", "역삼로 123", "06234"),
+        "nickname"
+    );
+
+    mockMvc.perform(post("/register")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.error").value("요청 값이 올바르지 않습니다."))
+        .andExpect(jsonPath("$.message").value("올바른 이메일 형식이 아닙니다."));
+  }
+
+  @Test
+  @DisplayName("비밀번호가 너무 짧으면 400 Bad Request")
+  void registerShortPassword() throws Exception {
+    UserRegisterRequest request = new UserRegisterRequest(
+        "test@rocket.com",
+        "123", // 너무 짧은 비밀번호
+        "25",
+        Gender.MALE,
+        new AddressRequest("서울시", "강남구", "역삼로 123", "06234"),
+        "nickname"
+    );
+
+    mockMvc.perform(post("/register")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.message").value("비밀번호는 최소 6글자 이상이어야 합니다."));
+  }
+
+  @Test
+  @DisplayName("Gender가 null이면 400 Bad Request")
+  void registerNullGender() throws Exception {
+    String requestJson = """
+        {
+          "email": "test@rocket.com",
+          "password": "123456",
+          "age": "25",
+          "gender": null,
+          "address": {
+            "state": "서울시",
+            "city" : "강남구",
+            "street": "역삼로 123",
+            "zipcCode": "06234"
+          },
+          "nickname": "nickname"
+        }
+        """;
+
+    mockMvc.perform(post("/register")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(requestJson))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.message").value("Gender 값이 null일 수 없습니다."));
+  }
+
+  @DisplayName("닉네임이 31자를 넘으면 400 Bad Request")
+  @Test
+  void registerNicknameTooLong() throws Exception {
+    String requestJson = """
+        {
+          "email": "test@rocket.com",
+          "password": "123456",
+          "age": "25",
+          "gender": "MALE",
+          "address": {
+            "state": "서울특별시",
+            "city": "강남구",
+            "street": "역삼로 123",
+            "zipCode": "06234"
+          },
+          "nickname": "%s"
+        }
+        """.formatted("a".repeat(31));
+
+    mockMvc.perform(post("/register")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(requestJson))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.message").value("닉네임은 최대 30자까지 입력 가능합니다."));
+  }
+
+  @DisplayName("주소 필드 중 zipCode가 누락되면 400 Bad Request")
+  @Test
+  void registerMissingZipCode() throws Exception {
+    String requestJson = """
+        {
+          "email": "test@rocket.com",
+          "password": "123456",
+          "age": "25",
+          "gender": "FEMALE",
+          "address": {
+            "state": "서울특별시",
+            "city": "강남구",
+            "street": "역삼로 123"
+          },
+          "nickname": "닉네임"
+        }
+        """;
+
+    mockMvc.perform(post("/register")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(requestJson))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.message").value("ZipCode 값이 비어 있을 수 없습니다."));
+  }
+
+  @DisplayName("중복된 이메일이면 409 Conflict")
+  @Test
+  void registerDuplicateEmail() throws Exception {
+    // given
+    String requestJson = """
+        {
+          "email": "duplicate@rocket.com",
+          "password": "123456",
+          "age": "25",
+          "gender": "MALE",
+          "address": {
+            "state": "서울특별시",
+            "city": "강남구",
+            "street": "역삼로 123",
+            "zipCode": "06234"
+          },
+          "nickname": "닉네임"
+        }
+        """;
+
+    doThrow(new DuplicateEmailException("duplicate@rocket.com"))
+        .when(authService).register(any(UserRegisterRequest.class));
+
+    mockMvc.perform(post("/register")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(requestJson))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.message").value("duplicate@rocket.com는 이미 사용중인 이메일 입니다."));
+
+  }
+
+}


### PR DESCRIPTION
### 📝 PR 설명

#### ✅ 주요 변경 사항
- `JwtProvider`에 대한 유닛 테스트 작성  
  - access/refresh 토큰 생성 및 유효성 검증
  - 만료 토큰 처리, 잘못된 토큰 처리 등 엣지 케이스 검증

- `JwtResolver` 유닛 테스트 작성  
  - `Bearer` 접두사 제거 및 유효성 검증

- `JwtAuthenticationFilter` 유닛 테스트 작성  
  - AccessToken, RefreshToken 유효 시 재발급 및 인증 처리
  - Redis 저장된 RefreshToken 불일치, 인증 실패 케이스 검증

- `CustomUserDetailsService` 유닛 테스트 작성  
  - 사용자 정보 조회 성공/실패 및 null 입력 예외 처리 검증

- `AuthServiceImpl` 유닛 테스트 작성  
  - 회원가입, 로그인, 재발급, 로그아웃 등 핵심 로직에 대한 다양한 조건 테스트
  - RefreshToken TTL 조건에 따른 분기 로직 검증

- 컨트롤러 계층 테스트 작성 (`@WebMvcTest`)
  - `AuthController`, `RegisterController`, `EmailCheckController`  
  - 유효성 검사 실패, 중복 이메일, 비정상 토큰 등 예외 상황 포함

- `@ActiveProfiles("test")` 추가  
  - 테스트 실행 시 별도 프로파일 적용으로 설정 충돌 방지

---


### 💡 고민한 점
- `AccessToken`이 만료되었을 때 RefreshToken을 통해 자동 재발급하는 구조에서,  
  필터 내부에서 인증 정보를 주입하기 위한 `AuthenticationManager` 처리 로직을 간결하게 유지하고자 노력했습니다.
- `AuthServiceImpl`의 `login` 및 `reissue` 로직에서 TTL 체크 분기를 테스트로 정확히 검증하기 위해  
  Mockito의 `when().thenReturn()` 조건을 세밀하게 설정하였습니다.
- `WebMvcTest`에서는 Security 설정 때문에 실제 필터가 적용되지 않으므로  
  `SecurityFilterChain`을 `@TestConfiguration`으로 별도 구성했습니다.

---