### PR TITLE
feat(User): 비밀번호 초기화 및 휴대폰 인증 기능 구현

### DIFF
--- a/src/main/java/com/rocket/RocketApplication.java
+++ b/src/main/java/com/rocket/RocketApplication.java
@@ -1,5 +1,6 @@
 package com.rocket;
 
+import com.rocket.commons.utils.EnvLoader;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -9,7 +10,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 public class RocketApplication {
 
   public static void main(String[] args) {
-    new com.rocket.utils.EnvLoader();
+    new EnvLoader();
     log.info("Rocket Application Started");
     log.info("JWT_SECRET = " + System.getProperty("JWT_SECRET"));
 

--- a/src/main/java/com/rocket/commons/utils/EnvLoader.java
+++ b/src/main/java/com/rocket/commons/utils/EnvLoader.java
@@ -1,4 +1,4 @@
-package com.rocket.utils;
+package com.rocket.commons.utils;
 
 import java.io.IOException;
 import java.nio.file.Files;

--- a/src/main/java/com/rocket/commons/utils/ResetTokenUtil.java
+++ b/src/main/java/com/rocket/commons/utils/ResetTokenUtil.java
@@ -1,0 +1,58 @@
+package com.rocket.commons.utils;
+
+import jakarta.annotation.PostConstruct;
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Base64;
+import java.util.UUID;
+import javax.crypto.Cipher;
+import javax.crypto.spec.SecretKeySpec;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ResetTokenUtil {
+
+  @Value("${security.reset-token.secret-key}")
+  private String secretKey;
+
+  @Value("${security.reset-token.algorithm}")
+  private String algorithm;
+
+  private Key key;
+  private Cipher cipher;
+
+  @PostConstruct
+  public void init() throws Exception {
+    key = new SecretKeySpec(secretKey.getBytes(StandardCharsets.UTF_8), "AES");
+    cipher = Cipher.getInstance(algorithm);
+  }
+
+  /**
+   * Reset Token 생성
+   */
+  public String generateResetToken() {
+    return UUID.randomUUID().toString();
+  }
+
+  /**
+   * 암호화
+   */
+  public String encrypt(String plainText) throws Exception {
+    cipher.init(Cipher.ENCRYPT_MODE, key);
+    byte[] encrypted = cipher.doFinal(plainText.getBytes(StandardCharsets.UTF_8));
+    return Base64.getEncoder().encodeToString(encrypted);
+  }
+
+  /**
+   * 복호화
+   */
+  public String decrypt(String encryptedText) throws Exception {
+    cipher.init(Cipher.DECRYPT_MODE, key);
+    byte[] decoded = Base64.getDecoder().decode(encryptedText);
+    byte[] decrypted = cipher.doFinal(decoded);
+    return new String(decrypted, StandardCharsets.UTF_8);
+  }
+}

--- a/src/main/java/com/rocket/domains/user/application/dto/request/PasswordChangeByTokenRequest.java
+++ b/src/main/java/com/rocket/domains/user/application/dto/request/PasswordChangeByTokenRequest.java
@@ -1,0 +1,11 @@
+package com.rocket.domains.user.application.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record PasswordChangeByTokenRequest(
+    @Schema(description = "암호화된 resetToken", example = "asdkjasd9834-sdf98asf-...")
+    String resetToken,
+
+    @Schema(description = "새로운 비밀번호", example = "newSecurePassword123!")
+    String newPassword
+) {}

--- a/src/main/java/com/rocket/domains/user/application/dto/request/PasswordResetTokenRequest.java
+++ b/src/main/java/com/rocket/domains/user/application/dto/request/PasswordResetTokenRequest.java
@@ -1,0 +1,11 @@
+package com.rocket.domains.user.application.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record PasswordResetTokenRequest(
+    @Schema(description = "사용자 이메일", example = "user@example.com")
+    String email,
+
+    @Schema(description = "사용자 전화번호", example = "01012345678")
+    String phoneNumber
+) {}

--- a/src/main/java/com/rocket/domains/user/application/dto/request/UserRegisterRequest.java
+++ b/src/main/java/com/rocket/domains/user/application/dto/request/UserRegisterRequest.java
@@ -28,7 +28,10 @@ public record UserRegisterRequest(
 
     @NotBlank(message = "닉네임은 필수 입력값입니다.")
     @Size(max = 30, message = "닉네임은 최대 30자까지 입력 가능합니다.")
-    String nickname
+    String nickname,
+
+    @NotBlank(message = "전화번호는 필수입니다.")
+    String phoneNumber
 ) {
 
 }

--- a/src/main/java/com/rocket/domains/user/application/service/UserMapper.java
+++ b/src/main/java/com/rocket/domains/user/application/service/UserMapper.java
@@ -15,7 +15,8 @@ public class UserMapper {
         Integer.parseInt(dto.age()),
         dto.gender(),
         toAddress(dto.address()),
-        dto.nickname()
+        dto.nickname(),
+        dto.phoneNumber()
     );
 
   }

--- a/src/main/java/com/rocket/domains/user/application/service/UserServiceImpl.java
+++ b/src/main/java/com/rocket/domains/user/application/service/UserServiceImpl.java
@@ -103,4 +103,15 @@ public class UserServiceImpl implements UserService {
     return userReader.existsByEmail(email);
   }
 
+
+  @Override
+  public Optional<User> findUserById(Long userId) {
+    return userReader.findById(userId);
+  }
+
+  @Override
+  public Long findUserIdByEmailAndPhoneNumber(String email, String phoneNumber) {
+    return userReader.findUserIdByEmailAndPhoneNumber(email, phoneNumber);
+  }
+
 }

--- a/src/main/java/com/rocket/domains/user/application/service/passwordReset/PasswordChanger.java
+++ b/src/main/java/com/rocket/domains/user/application/service/passwordReset/PasswordChanger.java
@@ -1,0 +1,40 @@
+package com.rocket.domains.user.application.service.passwordReset;
+
+import com.rocket.commons.exception.exceptions.UserNotFoundException;
+import com.rocket.domains.user.application.dto.request.PasswordChangeByTokenRequest;
+import com.rocket.domains.user.domain.entity.User;
+import com.rocket.domains.user.domain.service.UserService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+/**
+ * 해당 클래스는 인증 이후 사용되며 resetToken, newPassword를 전달받아 새로운 비밀번호는 User에 삽입하고 기존 발급되었던 resetToken을 삭제하는
+ * 코드입니다.
+ */
+@Service
+@RequiredArgsConstructor
+public class PasswordChanger {
+
+  private final ResetTokenManager tokenStore;
+  private final UserService userService;
+  private final PasswordEncoder passwordEncoder;
+  private final VerificationService verificationService;
+
+  public void resetPassword(@Valid PasswordChangeByTokenRequest request) throws Exception {
+    Long userId = tokenStore.validateToken(request.resetToken());
+    boolean verified = verificationService.isVerified(userId);
+    if (!verified) {
+      throw new IllegalArgumentException("휴대폰 인증이 완료되지 않았습니다.");
+    }
+
+    verificationService.clearVerification(userId); // 인증 완료 후 즉시 삭제
+
+    User user = userService.findUserById(userId)
+        .orElseThrow(() -> new UserNotFoundException("해당 유저를 찾을 수 없습니다."));
+
+    String encryptedPassword = passwordEncoder.encode(request.newPassword());
+    user.updatePassword(encryptedPassword); // DB에 password 저장 시 암호화하여 저장
+  }
+}

--- a/src/main/java/com/rocket/domains/user/application/service/passwordReset/ResetTokenIssuer.java
+++ b/src/main/java/com/rocket/domains/user/application/service/passwordReset/ResetTokenIssuer.java
@@ -1,0 +1,39 @@
+package com.rocket.domains.user.application.service.passwordReset;
+
+import com.rocket.commons.exception.exceptions.UserNotFoundException;
+import com.rocket.commons.utils.ResetTokenUtil;
+import com.rocket.domains.user.domain.entity.User;
+import com.rocket.domains.user.domain.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/**
+ * 해당 코드는 유저가 비밀번호를 변경하기 위해 email과 phoneNumber를 입력하면 실행되는 코드로 email을 통해 유저의 정보를 찾고 해당 유저가 존재한다면
+ * token을 발급하고 resetTokenManager를 통해 토큰을 관리하고 return으로 사용자에게 암호화된 토큰을 전송한다.
+ */
+@Service
+@RequiredArgsConstructor
+public class ResetTokenIssuer {
+
+  private final UserService userService;
+  private final ResetTokenManager resetTokenManager;
+  private final ResetTokenUtil resetTokenUtil;
+
+  public String initiateReset(String email, String phoneNumber) throws Exception {
+    User user = userService.findUserByEmail(email)
+        .filter(u -> u.getPhoneNumber().equals(phoneNumber)) // phoneNumber 비교
+        .orElseThrow(() -> new UserNotFoundException("해당 정보로 유저를 찾을 수 없습니다."));
+
+    String token = resetTokenUtil.generateResetToken();
+    resetTokenManager.storeToken(user.getId(), token);
+
+    return resetTokenUtil.encrypt(token); // 암호화해서 사용자에게 전달
+  }
+
+  public String init(Long userId) throws Exception {
+    String token = resetTokenUtil.generateResetToken();
+    resetTokenManager.storeToken(userId, token);
+
+    return resetTokenUtil.encrypt(token);
+  }
+}

--- a/src/main/java/com/rocket/domains/user/application/service/passwordReset/ResetTokenManager.java
+++ b/src/main/java/com/rocket/domains/user/application/service/passwordReset/ResetTokenManager.java
@@ -1,0 +1,52 @@
+package com.rocket.domains.user.application.service.passwordReset;
+
+import com.rocket.commons.exception.exceptions.InvalidTokenException;
+import com.rocket.commons.utils.ResetTokenUtil;
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+/**
+ * 해당 코드는 Redis에서 resetToken을 관리하기 위해 만들어진 클래스이다. redis에 저장하는 기능 유효한 토큰인지 검증하는 기능 토큰을 제거하는 기능 을
+ * 제공한다.
+ */
+@Service
+@RequiredArgsConstructor
+public class ResetTokenManager {
+
+  private final RedisTemplate<String, String> redisTemplate;
+
+  private static final Duration TOKEN_EXPIRY = Duration.ofMinutes(5);
+  private final ResetTokenUtil resetTokenUtil;
+
+  /**
+   * 여기 넘어온 token은 암호화가 됐을까? redis의 토큰은 암호화 X
+   *
+   * @param userId
+   * @param token
+   */
+  public void storeToken(Long userId, String token) {
+    String key = getKey(token);
+    redisTemplate.opsForValue().set(key, String.valueOf(userId), TOKEN_EXPIRY);
+  }
+
+  public Long validateToken(String encryptedToken) throws Exception {
+    String rawToken = resetTokenUtil.decrypt(encryptedToken);
+    String key = getKey(rawToken);
+    String userId = redisTemplate.opsForValue().get(key);
+    if (userId == null) {
+      throw new InvalidTokenException("유효하지 않거나 만료된 토큰입니다.");
+    }
+    clearToken(rawToken); // 내부적 토큰 삭제
+    return Long.parseLong(userId);
+  }
+
+  public void clearToken(String token) {
+    redisTemplate.delete(getKey(token));
+  }
+
+  private String getKey(String token) {
+    return "reset-token:" + token;
+  }
+}

--- a/src/main/java/com/rocket/domains/user/application/service/passwordReset/VerificationService.java
+++ b/src/main/java/com/rocket/domains/user/application/service/passwordReset/VerificationService.java
@@ -1,0 +1,24 @@
+package com.rocket.domains.user.application.service.passwordReset;
+
+import com.rocket.domains.user.domain.repository.VerificationStore;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class VerificationService {
+
+  private final VerificationStore verificationStore;
+
+  public void verify(Long userId) {
+    verificationStore.storeVerification(userId);
+  }
+
+  public boolean isVerified(Long userId) {
+    return verificationStore.isVerified(userId);
+  }
+
+  public void clearVerification(Long userId) {
+    verificationStore.deleteVerification(userId);
+  }
+}

--- a/src/main/java/com/rocket/domains/user/domain/entity/User.java
+++ b/src/main/java/com/rocket/domains/user/domain/entity/User.java
@@ -2,6 +2,7 @@ package com.rocket.domains.user.domain.entity;
 
 import com.rocket.domains.user.application.dto.request.AddressRequest;
 import com.rocket.domains.user.domain.enums.Gender;
+import io.micrometer.core.instrument.step.StepRegistryConfig;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -41,7 +42,7 @@ public class User {
   private String email;
 
   @NotBlank(message = "비밀번호는 필수 입력값입니다.")
-  @Size(min = 6, message = "비밀번호는 최소 6자 이상이어야 합니다.")
+  @Size(min = 10, message = "비밀번호는 최소 10자 이상이어야 합니다.")
   @Column(name = "password", nullable = false)
   @Comment("비밀번호")
   private String password;
@@ -70,22 +71,27 @@ public class User {
   @Embedded
   private Address address;
 
+  @NotNull(message = "전화번호는 필수 입력값입니다.")
+  @NotBlank
+  private String phoneNumber;
+
   private User(String email, String password, int age, Gender gender, Address address,
-      String nickname) {
+      String nickname, String phoneNumber) {
     this.email = email;
     this.password = password;
     this.age = age;
     this.gender = gender;
     this.address = address;
     this.nickname = nickname;
+    this.phoneNumber = phoneNumber;
   }
 
   // @VisibleForTesting
   public static User createWithIdForTest(
       Long id, String email, String password, int age, Gender gender, Address address,
-      String nickname
+      String nickname, String phoneNumber
   ) {
-    User user = new User(email, password, age, gender, address, nickname);
+    User user = new User(email, password, age, gender, address, nickname, phoneNumber);
     user.id = id;
     return user;
   }
@@ -98,9 +104,10 @@ public class User {
       @Min(0) int age,
       @NotNull Gender gender,
       @Valid @NotNull Address address,
-      @NotBlank String nickname
+      @NotBlank String nickname,
+      @NotBlank String phoneNumber
   ) {
-    return new User(email, password, age, gender, address, nickname);
+    return new User(email, password, age, gender, address, nickname, phoneNumber);
   }
 
 
@@ -113,12 +120,12 @@ public class User {
     return age == user.age && Objects.equals(id, user.id) && Objects.equals(email,
         user.email) && Objects.equals(password, user.password) && Objects.equals(
         nickname, user.nickname) && gender == user.gender && Objects.equals(address,
-        user.address);
+        user.address) && Objects.equals(phoneNumber, user.phoneNumber);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, email, password, nickname, age, gender, address);
+    return Objects.hash(id, email, password, nickname, age, gender, address, phoneNumber);
   }
 
   public void updateNickname(String newNickname) {
@@ -128,11 +135,25 @@ public class User {
     this.nickname = newNickname;
   }
 
+  public void updatePassword(String newPassword) {
+    if (newPassword == null || newPassword.length() < 6) {
+      throw new IllegalArgumentException("비밀번호 형식이 올바르지 않습니다.");
+    }
+    this.password = newPassword;
+  }
+
   public void updateAge(Integer age) {
     if (age < 0) {
       throw new IllegalArgumentException("나이는 음수일 수 없습니다.");
     }
     this.age = age;
+  }
+
+  public void updatePhoneNumber(String newPhoneNumber) {
+    if (newPhoneNumber == null) {
+      throw new IllegalArgumentException("전화번호는 null일 수 없습니다.");
+    }
+    this.phoneNumber = newPhoneNumber;
   }
 
   public void updateGender(Gender gender) {

--- a/src/main/java/com/rocket/domains/user/domain/repository/UserReader.java
+++ b/src/main/java/com/rocket/domains/user/domain/repository/UserReader.java
@@ -17,4 +17,6 @@ public interface UserReader {
   Boolean existsByNickname(String nickname);
 
   List<User> findAll();
+
+  Long findUserIdByEmailAndPhoneNumber(String email, String phoneNumber);
 }

--- a/src/main/java/com/rocket/domains/user/domain/repository/VerificationStore.java
+++ b/src/main/java/com/rocket/domains/user/domain/repository/VerificationStore.java
@@ -1,0 +1,10 @@
+package com.rocket.domains.user.domain.repository;
+
+public interface VerificationStore {
+
+  void storeVerification(Long userId);
+
+  boolean isVerified(Long userId);
+
+  void deleteVerification(Long userId);
+}

--- a/src/main/java/com/rocket/domains/user/domain/service/UserService.java
+++ b/src/main/java/com/rocket/domains/user/domain/service/UserService.java
@@ -24,4 +24,10 @@ public interface UserService {
   Optional<User> findUserByEmail(String email);
 
   Boolean existsByEmail(String email);
+
+
+  Optional<User> findUserById(Long userId);
+
+  Long findUserIdByEmailAndPhoneNumber(String email, String phoneNumber);
+
 }

--- a/src/main/java/com/rocket/domains/user/infrastructure/persistence/impl/UserReaderImpl.java
+++ b/src/main/java/com/rocket/domains/user/infrastructure/persistence/impl/UserReaderImpl.java
@@ -1,5 +1,6 @@
 package com.rocket.domains.user.infrastructure.persistence.impl;
 
+import com.rocket.commons.exception.exceptions.UserNotFoundException;
 import com.rocket.domains.user.domain.entity.User;
 import com.rocket.domains.user.domain.repository.UserReader;
 import com.rocket.domains.user.infrastructure.persistence.jpa.UserJpaRepository;
@@ -44,5 +45,11 @@ public class UserReaderImpl implements UserReader {
   @Override
   public List<User> findAll() {
     return userJpaRepository.findAll();
+  }
+
+  @Override
+  public Long findUserIdByEmailAndPhoneNumber(String email, String phoneNumber) {
+    return userJpaRepository.findUserIdByEmailAndPhoneNumber(email, phoneNumber)
+        .orElseThrow(() -> new UserNotFoundException(email));
   }
 }

--- a/src/main/java/com/rocket/domains/user/infrastructure/persistence/jpa/UserJpaRepository.java
+++ b/src/main/java/com/rocket/domains/user/infrastructure/persistence/jpa/UserJpaRepository.java
@@ -72,4 +72,9 @@ public interface UserJpaRepository extends JpaRepository<User, Long> {
 
   Boolean existsByNickname(
       @NotBlank(message = "닉네임은 필수 입력값입니다.") @Size(max = 30, message = "닉네임은 최대 30자까지 입력 가능합니다.") String nickname);
+
+  Optional<Long> findUserIdByEmailAndPhoneNumber(
+      @NotBlank(message = "이메일은 필수 입력값입니다.") @Email(message = "올바른 이메일 형식이 아닙니다.") String email,
+      @NotNull(message = "전화번호는 필수 입력값입니다.") @NotBlank String phoneNumber);
+
 }

--- a/src/main/java/com/rocket/domains/user/infrastructure/persistence/redis/RedisVerificationStore.java
+++ b/src/main/java/com/rocket/domains/user/infrastructure/persistence/redis/RedisVerificationStore.java
@@ -1,0 +1,34 @@
+package com.rocket.domains.user.infrastructure.persistence.redis;
+
+import com.rocket.domains.user.domain.repository.VerificationStore;
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class RedisVerificationStore implements VerificationStore {
+
+  private final RedisTemplate<String, String> redisTemplate;
+  private final static Duration TTL = Duration.ofMinutes(5);
+
+  private String getKey(Long userId) {
+    return "password-change-verified:" + userId;
+  }
+
+  @Override
+  public void storeVerification(Long userId) {
+    redisTemplate.opsForValue().set(getKey(userId), "true", TTL);
+  }
+
+  @Override
+  public boolean isVerified(Long userId) {
+    return "true".equals(redisTemplate.opsForValue().get(getKey(userId)));
+  }
+
+  @Override
+  public void deleteVerification(Long userId) {
+    redisTemplate.delete(getKey(userId));
+  }
+}

--- a/src/main/java/com/rocket/domains/user/presentation/ResetPasswordController.java
+++ b/src/main/java/com/rocket/domains/user/presentation/ResetPasswordController.java
@@ -1,0 +1,36 @@
+package com.rocket.domains.user.presentation;
+
+import com.rocket.domains.user.application.dto.request.PasswordChangeByTokenRequest;
+import com.rocket.domains.user.application.service.passwordReset.PasswordChanger;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+@Tag(name = "Password Reset", description = "resetToken을 통한 비밀번호 재설정")
+public class ResetPasswordController {
+
+  private final PasswordChanger passwordChanger;
+
+  @PostMapping("/reset-password")
+  @Operation(
+      summary = "비밀번호 재설정",
+      description = "resetToken과 새 비밀번호를 입력받아 비밀번호를 변경합니다."
+  )
+  @ApiResponse(responseCode = "200", description = "비밀번호 변경 성공")
+  public ResponseEntity<String> resetPassword(
+      @RequestBody @Valid PasswordChangeByTokenRequest request)
+      throws Exception {
+    passwordChanger.resetPassword(request);
+    return ResponseEntity.ok("비밀번호가 성공적으로 변경되었습니다.");
+  }
+}

--- a/src/main/java/com/rocket/domains/user/presentation/VerificationController.java
+++ b/src/main/java/com/rocket/domains/user/presentation/VerificationController.java
@@ -1,0 +1,53 @@
+package com.rocket.domains.user.presentation;
+
+import com.rocket.domains.user.application.dto.request.PasswordResetTokenRequest;
+import com.rocket.domains.user.application.service.passwordReset.ResetTokenIssuer;
+import com.rocket.domains.user.application.service.passwordReset.VerificationService;
+import com.rocket.domains.user.domain.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/auth")
+@Log4j2
+@RequiredArgsConstructor
+@Tag(name = "Password Verification", description = "비밀번호 변경을 위한 휴대폰 인증 및 resetToken 발급")
+public class VerificationController {
+
+  private final VerificationService verificationService;
+  private final UserService userService;
+  private final ResetTokenIssuer resetTokenIssuer;
+
+  @PostMapping("/verify-phone")
+  @Operation(
+      summary = "휴대폰 인증 + resetToken 발급",
+      description = "이메일과 전화번호를 통해 사용자를 인증하고, resetToken을 발급합니다."
+  )
+  @ApiResponse(responseCode = "200", description = "인증 성공 및 토큰 발급")
+  public ResponseEntity<Map<String, String>> verifyPhone(
+      @RequestBody PasswordResetTokenRequest request)
+      throws Exception {
+    Long userId = userService.findUserIdByEmailAndPhoneNumber(request.email(),
+        request.phoneNumber());
+    verificationService.verify(userId); // 내부에서 Redis에 인증 성공 처리
+
+    String encryptedToken = resetTokenIssuer.init(userId);
+    log.info("비밀번호 재설정 토큰 발급 완료. email={} phone={}", request.email(), request.phoneNumber());
+
+    Map<String, String> response = Map.of(
+        "message", "휴대폰 인증이 완료되었습니다.",
+        "resetToken", encryptedToken
+    );
+
+    return ResponseEntity.ok(response);
+  }
+}


### PR DESCRIPTION
## ✅ 주요 기능

### 1. 휴대폰 인증 & resetToken 발급
`/auth/verify-phone` 엔드포인트 추가

- 사용자 이메일과 전화번호를 기반으로 사용자를 조회하고, 인증되었음을 Redis에 저장
- 동시에 resetToken을 생성하고, 암호화하여 프론트엔드에 전달
- Swagger 문서화 적용

### 2. resetToken을 통한 비밀번호 재설정
`/auth/reset-password` 엔드포인트 추가

- 전달받은 resetToken을 복호화하여 사용자 ID 확인
- Redis를 통해 해당 토큰과 인증 여부를 검증한 후, 새로운 비밀번호로 업데이트
- 인증이 완료된 유저에 대해서는 Redis 인증 키 삭제 처리
- Swagger 문서화 적용

---

## 🧩 추가 구현 내용

### 📦 DTO
- `PasswordResetTokenRequest`: 이메일과 전화번호를 받기 위한 DTO  
- `PasswordChangeByTokenRequest`: 암호화된 resetToken과 새로운 비밀번호를 담는 DTO

### 🧠 서비스 및 유틸
- `VerificationService`: 인증 상태 저장 및 검증 담당  
- `VerificationStore`: 인증 저장소 인터페이스  
- `RedisVerificationStore`: Redis 기반 인증 저장소 구현체  
- `ResetTokenIssuer`: 사용자 인증 후 resetToken 생성 및 암호화  
- `ResetTokenManager`: resetToken 저장, 검증, 삭제 기능  
- `ResetTokenUtil`: AES 암호화 및 복호화 유틸  

### 🧱 인프라
- `UserJpaRepository`, `UserReaderImpl`: 이메일 + 전화번호로 사용자 ID를 조회하는 기능 추가  
- `User 엔티티`: `phoneNumber` 필드 및 관련 업데이트 메서드 추가  
- `UserRegisterRequest` 및 관련 Mapper 수정  

---

## 💬 고민한 점
- `resetToken`을 암호화된 값으로 클라이언트에 전달하여 보안 강화  
- 휴대폰 인증 결과를 Redis에 5분간 저장하여 인증 상태를 임시로 유지  
- 인증이 완료된 이후에는 Redis의 인증 키를 명시적으로 삭제하여 불필요한 데이터 유지 방지  
- 비밀번호 검증 흐름에서 Redis, Token, User 검증 순서를 어떻게 구성할지 설계  

---

## 📎 관련 이슈
Refs: #12, #14
