### PR TITLE
Feature/refactor posts crud

### DIFF
--- a/src/main/java/com/rocket/commons/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/rocket/commons/exception/GlobalExceptionHandler.java
@@ -1,7 +1,9 @@
 package com.rocket.commons.exception;
 
+import com.rocket.commons.exception.exceptions.AccessDeniedCustomException;
 import com.rocket.commons.exception.exceptions.DuplicateEmailException;
 import com.rocket.commons.exception.exceptions.DuplicateLikeException;
+import com.rocket.commons.exception.exceptions.DuplicateNicknameException;
 import com.rocket.commons.exception.exceptions.InvalidEmailFormatException;
 import com.rocket.commons.exception.exceptions.InvalidTokenException;
 import com.rocket.commons.exception.exceptions.LoginFailedException;
@@ -57,7 +59,17 @@ public class GlobalExceptionHandler {
       HttpServletRequest request) {
     return ResponseEntity.status(HttpStatus.CONFLICT)
         .body(
-            ErrorResponse.of(409, "중복되어 해당 이메일을 사용할 수 없습니다.", ex.getMessage(),
+            ErrorResponse.of(409, "이미 사용중인 Email입니다.", ex.getMessage(),
+                request.getRequestURI())
+        );
+  }
+
+  @ExceptionHandler(DuplicateNicknameException.class)
+  public ResponseEntity<ErrorResponse> handleDuplicateEmail(DuplicateNicknameException ex,
+      HttpServletRequest request) {
+    return ResponseEntity.status(HttpStatus.CONFLICT)
+        .body(
+            ErrorResponse.of(409, "이미 사용중인 닉네임입니다.", ex.getMessage(),
                 request.getRequestURI())
         );
   }
@@ -135,6 +147,13 @@ public class GlobalExceptionHandler {
     );
 
     return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
+  }
+
+  @ExceptionHandler(AccessDeniedCustomException.class)
+  public ResponseEntity<ErrorResponse> handleAccessDeniedCustom(AccessDeniedCustomException ex,
+      HttpServletRequest request) {
+    return ResponseEntity.status(HttpStatus.FORBIDDEN)
+        .body(ErrorResponse.of(403, "권한이 없습니다.", ex.getMessage(), request.getRequestURI()));
   }
 
   @ExceptionHandler(Exception.class)

--- a/src/main/java/com/rocket/commons/exception/exceptions/AccessDeniedCustomException.java
+++ b/src/main/java/com/rocket/commons/exception/exceptions/AccessDeniedCustomException.java
@@ -1,0 +1,9 @@
+package com.rocket.commons.exception.exceptions;
+
+public class AccessDeniedCustomException extends RuntimeException {
+
+  public AccessDeniedCustomException(String message) {
+    super(message);
+  }
+
+}

--- a/src/main/java/com/rocket/commons/exception/exceptions/DuplicateNicknameException.java
+++ b/src/main/java/com/rocket/commons/exception/exceptions/DuplicateNicknameException.java
@@ -1,0 +1,9 @@
+package com.rocket.commons.exception.exceptions;
+
+public class DuplicateNicknameException extends RuntimeException {
+
+  public DuplicateNicknameException(String message) {
+    super(String.format("%s는 이미 사용중인 닉네임 입니다.", message));
+  }
+
+}

--- a/src/main/java/com/rocket/commons/security/handler/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/rocket/commons/security/handler/CustomAccessDeniedHandler.java
@@ -1,0 +1,28 @@
+package com.rocket.commons.security.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rocket.commons.exception.exceptions.AccessDeniedCustomException;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  @Override
+  public void handle(HttpServletRequest request, HttpServletResponse response,
+      AccessDeniedException accessDeniedException) throws IOException, ServletException {
+    response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+    response.setContentType("application/json;charset=utf-8");
+
+    String message = "관리자의 권한이 필요합니다.";
+    String body = objectMapper.writeValueAsString(new AccessDeniedCustomException(message));
+    response.getWriter().write(body);
+  }
+}

--- a/src/main/java/com/rocket/domains/user/application/dto/request/AddressRequest.java
+++ b/src/main/java/com/rocket/domains/user/application/dto/request/AddressRequest.java
@@ -1,5 +1,6 @@
 package com.rocket.domains.user.application.dto.request;
 
+import com.rocket.domains.user.domain.entity.Address;
 import jakarta.validation.constraints.NotBlank;
 
 public record AddressRequest(
@@ -16,4 +17,7 @@ public record AddressRequest(
     String zipCode
 ) {
 
+  public Address toAddress() {
+    return new Address(state, city, street, zipCode);
+  }
 }

--- a/src/main/java/com/rocket/domains/user/application/dto/request/UserUpdateRequest.java
+++ b/src/main/java/com/rocket/domains/user/application/dto/request/UserUpdateRequest.java
@@ -1,26 +1,19 @@
 package com.rocket.domains.user.application.dto.request;
 
 import com.rocket.domains.user.domain.enums.Gender;
-import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
 public record UserUpdateRequest(
-    @NotBlank(message = "이메일은 필수입니다.")
-    String email,
-
-    @Min(value = 0, message = "나이는 음수일 수 없습니다.")
+    String email, // 포함!
     Integer age,
-
-    // 업데이트 시 선택적 필드 (null 허용)
     Gender gender,
-
-    // 업데이트 시 선택적 필드 (null 허용)
     AddressRequest address,
-
-    // 업데이트 시 선택적 필드 (null 허용)
     @Size(max = 30, message = "닉네임은 최대 30자까지 입력 가능합니다.")
-    String nickname
+    String nickname,
+    String phoneNumber
 ) {
 
+  public UserUpdateRequest withEmail(String email) {
+    return new UserUpdateRequest(email, age, gender, address, nickname, phoneNumber);
+  }
 }

--- a/src/main/java/com/rocket/domains/user/application/service/UserServiceImpl.java
+++ b/src/main/java/com/rocket/domains/user/application/service/UserServiceImpl.java
@@ -8,6 +8,7 @@ import com.rocket.domains.user.domain.entity.User;
 import com.rocket.domains.user.domain.repository.UserReader;
 import com.rocket.domains.user.domain.repository.UserWriter;
 import com.rocket.domains.user.domain.service.UserService;
+import com.rocket.domains.user.domain.validator.UserValidator;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -20,12 +21,14 @@ public class UserServiceImpl implements UserService {
   private final UserReader userReader;
   private final UserWriter userWriter;
   private final PasswordEncoder passwordEncoder;
+  private final UserValidator userValidator;
 
   public UserServiceImpl(UserReader userReader, UserWriter userWriter,
-      PasswordEncoder passwordEncoder) {
+      PasswordEncoder passwordEncoder, UserValidator userValidator) {
     this.userReader = userReader;
     this.userWriter = userWriter;
     this.passwordEncoder = passwordEncoder;
+    this.userValidator = userValidator;
   }
 
   @Override
@@ -58,28 +61,11 @@ public class UserServiceImpl implements UserService {
     User user = userReader.findByEmail(dto.email())
         .orElseThrow(() -> new UserNotFoundException(dto.email()));
 
-    boolean isUpdated = false;
-
-    if (dto.age() != null) {
-      user.updateAge(dto.age());
-      isUpdated = true;
-    }
-    if (dto.gender() != null) {
-      user.updateGender(dto.gender());
-      isUpdated = true;
-    }
-    if (dto.address() != null) {
-      user.updateAddress(dto.address());
-      isUpdated = true;
-    }
-    if (dto.nickname() != null) {
-      user.updateNickname(dto.nickname());
-      isUpdated = true;
+    if (dto.nickname() != null && !dto.nickname().equals(user.getNickname())) {
+      userValidator.validateUserNicknameExists(dto.nickname());
     }
 
-    if (!isUpdated) {
-      throw new IllegalArgumentException("변경된 내용이 없습니다.");
-    }
+    user.updateFrom(dto);
 
     return UserInfoResponse.fromUser(user);
   }

--- a/src/main/java/com/rocket/domains/user/domain/entity/User.java
+++ b/src/main/java/com/rocket/domains/user/domain/entity/User.java
@@ -1,6 +1,7 @@
 package com.rocket.domains.user.domain.entity;
 
 import com.rocket.domains.user.application.dto.request.AddressRequest;
+import com.rocket.domains.user.application.dto.request.UserUpdateRequest;
 import com.rocket.domains.user.domain.enums.Gender;
 import io.micrometer.core.instrument.step.StepRegistryConfig;
 import jakarta.persistence.Column;
@@ -128,8 +129,37 @@ public class User {
     return Objects.hash(id, email, password, nickname, age, gender, address, phoneNumber);
   }
 
+  public void updateFrom(UserUpdateRequest dto) {
+    boolean isUpdated = false;
+
+    if (dto.age() != null && this.age != dto.age()) {
+      updateAge(dto.age());
+      isUpdated = true;
+    }
+    if (dto.gender() != null && this.gender != dto.gender()) {
+      updateGender(dto.gender());
+      isUpdated = true;
+    }
+    if (dto.address() != null && !this.address.equals(dto.address().toAddress())) {
+      updateAddress(dto.address());
+      isUpdated = true;
+    }
+    if (dto.nickname() != null && !this.nickname.equals(dto.nickname())) {
+      updateNickname(dto.nickname());
+      isUpdated = true;
+    }
+    if (dto.phoneNumber() != null && !this.phoneNumber.equals(dto.phoneNumber())) {
+      updatePhoneNumber(dto.phoneNumber());
+      isUpdated = true;
+    }
+
+    if (!isUpdated) {
+      throw new IllegalArgumentException("변경된 내용이 없습니다.");
+    }
+  }
+
   public void updateNickname(String newNickname) {
-    if (newNickname == null) {
+    if (newNickname == null || newNickname.isEmpty()) {
       throw new IllegalArgumentException("닉네임은 null일 수 없습니다.");
     }
     this.nickname = newNickname;

--- a/src/main/java/com/rocket/domains/user/domain/validator/UserValidator.java
+++ b/src/main/java/com/rocket/domains/user/domain/validator/UserValidator.java
@@ -16,4 +16,13 @@ public class UserValidator {
       throw new UserNotFoundException(String.valueOf(userId));
     }
   }
+
+  public void validateUserNicknameExists(String nickname) {
+    if (nickname == null || nickname.isEmpty()) {
+      throw new IllegalArgumentException("닉네임이 존재하지 않습니다.");
+    }
+    if (userReader.existsByNickname(nickname)) {
+      throw new IllegalArgumentException("중복되는 닉네임이 존재합니다.");
+    }
+  }
 }


### PR DESCRIPTION
## 🚀 사용자(Role) 기반 인가 및 수정 기능 개선 PR

### 📌 주요 변경사항

#### 🧩 User 엔티티에 `Role` 필드 추가
- 역할(Role)을 기반으로 권한 제어가 가능하도록 필드 및 관련 로직 반영
- `User.create()` 및 테스트용 `createWithIdForTest()`에 `Role` 필드 추가
- `@Enumerated(EnumType.STRING)` 설정으로 DB에 명확하게 문자열로 저장

#### ✏ 사용자 수정 기능 향상
- `UserUpdateRequest`에 `phoneNumber`, `withEmail()` 메서드 추가
- `User.updateFrom(dto)` 메서드를 통해 수정 로직을 엔티티 내부로 캡슐화
- 닉네임 중복 시 `DuplicateNicknameException` 발생하도록 `UserValidator` 연동

#### 🔄 DTO 기능 개선
- `AddressRequest`에 `.toAddress()` 변환 메서드 추가로 변환 로직 단순화

#### ❗ 예외 처리 강화
- `DuplicateNicknameException` 커스텀 예외 클래스 정의
- `GlobalExceptionHandler`에 해당 예외에 대한 핸들러 추가 (409 Conflict)
- `AccessDeniedCustomException` 및 `CustomAccessDeniedHandler` 추가  
  → 관리자가 아닌 사용자의 접근 차단 시 일관된 JSON 에러 응답 제공

---

### 🔐 인증 / 인가 개선 사항

- `UserController`에 `@PreAuthorize` 어노테이션 적용  
  - `GET /users`, `DELETE /users/{email}` 등은 **관리자 전용 API**로 보호  
  - `PUT /users/me`는 **로그인한 사용자 본인만 수정 가능**
- `CustomAccessDeniedHandler` 추가  
  - 인가 실패 시 JSON 포맷으로 통일된 응답 제공 (`403 Forbidden`)