### PR TITLE
refactor(user): User 엔티티 구조 전면 리팩토링

### DIFF
--- a/src/main/java/com/rocket/config/JpaConfig.java
+++ b/src/main/java/com/rocket/config/JpaConfig.java
@@ -1,0 +1,10 @@
+package com.rocket.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+
+}

--- a/src/main/java/com/rocket/domains/posts/application/service/PostServiceImpl.java
+++ b/src/main/java/com/rocket/domains/posts/application/service/PostServiceImpl.java
@@ -18,7 +18,6 @@ import com.rocket.domains.user.domain.service.UserLookupService;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -44,7 +43,6 @@ public class PostServiceImpl implements PostService {
         .orElseThrow(() -> new UserNotFoundException("로그인 유저를 찾을 수 없습니다."));
 
     Post post = PostMapper.toEntity(dto, author);
-
 
     Post savedPost = postWriter.savePost(post);
     if (savedPost == null) {
@@ -76,7 +74,7 @@ public class PostServiceImpl implements PostService {
     User user = userFacade.findById(userId)
         .orElseThrow(() -> new UserNotFoundException(String.valueOf(userId)));
 
-    if (!post.isOwnedBy(user) && !user.isAdmin()) {
+    if (!post.canBeModifiedBy(user)) {
       throw new AccessDeniedCustomException("게시글 수정 권한이 없습니다.");
     }
 
@@ -92,7 +90,7 @@ public class PostServiceImpl implements PostService {
 
     User user = userFacade.getByIdOrThrow(userId);
 
-    if (!post.isOwnedBy(user) && !user.isAdmin()){
+    if (!post.isOwnedBy(user) && !user.getRole().isAdmin()) {
       throw new AccessDeniedCustomException("게시글을 삭제할 권한이 없습니다.");
     }
 

--- a/src/main/java/com/rocket/domains/posts/domain/entity/Post.java
+++ b/src/main/java/com/rocket/domains/posts/domain/entity/Post.java
@@ -2,7 +2,6 @@ package com.rocket.domains.posts.domain.entity;
 
 import com.rocket.domains.posts.application.dto.request.PostUpdateRequest;
 import com.rocket.domains.user.domain.entity.User;
-import com.rocket.domains.user.domain.enums.Role;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -104,6 +103,9 @@ public class Post {
     return this.author.getId().equals(user.getId());
   }
 
+  public boolean canBeModifiedBy(User user) {
+    return this.isOwnedBy(user) || user.getRole().isAdmin();
+  }
 
 
   @Override

--- a/src/main/java/com/rocket/domains/user/application/dto/request/UserRegisterRequest.java
+++ b/src/main/java/com/rocket/domains/user/application/dto/request/UserRegisterRequest.java
@@ -6,6 +6,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 public record UserRegisterRequest(
@@ -32,12 +33,13 @@ public record UserRegisterRequest(
     String nickname,
 
     @NotBlank(message = "전화번호는 필수입니다.")
+    @Pattern(regexp = "^\\d{10,11}$", message = "전화번호는 숫자만 입력해주세요.")
     String phoneNumber,
 
     @NotNull(message = "역할은 필수입니다.")
     Role role,
 
-    String profileImageUrl
+    String profileUrl
 ) {
 
 }

--- a/src/main/java/com/rocket/domains/user/application/dto/request/UserUpdateRequest.java
+++ b/src/main/java/com/rocket/domains/user/application/dto/request/UserUpdateRequest.java
@@ -10,10 +10,11 @@ public record UserUpdateRequest(
     AddressRequest address,
     @Size(max = 30, message = "닉네임은 최대 30자까지 입력 가능합니다.")
     String nickname,
-    String phoneNumber
+    String phoneNumber,
+    String profileUrl
 ) {
 
   public UserUpdateRequest withEmail(String email) {
-    return new UserUpdateRequest(email, age, gender, address, nickname, phoneNumber);
+    return new UserUpdateRequest(email, age, gender, address, nickname, phoneNumber, profileUrl);
   }
 }

--- a/src/main/java/com/rocket/domains/user/application/service/UserMapper.java
+++ b/src/main/java/com/rocket/domains/user/application/service/UserMapper.java
@@ -19,9 +19,8 @@ public class UserMapper {
         dto.nickname(),
         dto.phoneNumber(),
         dto.role(),
-        dto.profileImageUrl()
+        dto.profileUrl()
     );
-
   }
 
   private static Address toAddress(AddressRequest dto) {
@@ -49,7 +48,7 @@ public class UserMapper {
     return new UserSimpleInfoResponse(
         user.getId(),
         user.getNickname(),
-        user.getProfileImageUrl()
+        user.getProfileUrl()
     );
   }
 }

--- a/src/main/java/com/rocket/domains/user/domain/entity/User.java
+++ b/src/main/java/com/rocket/domains/user/domain/entity/User.java
@@ -4,9 +4,11 @@ import com.rocket.domains.user.application.dto.request.AddressRequest;
 import com.rocket.domains.user.application.dto.request.UserUpdateRequest;
 import com.rocket.domains.user.domain.enums.Gender;
 import com.rocket.domains.user.domain.enums.Role;
+import com.rocket.domains.user.domain.enums.UserStatus;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
@@ -19,15 +21,20 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import java.time.LocalDateTime;
 import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Comment;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
-@Table(name = "User")
+@Table(name = "users")
+@EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class User {
@@ -82,13 +89,41 @@ public class User {
   @Comment("역할")
   private Role role;
 
-  @Column(name = "profile_image_url")
+  @Column(name = "profile_url")
   @Comment("프로필 이미지 URL")
-  private String profileImageUrl;
+  private String profileUrl;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  @Comment("계정 상태")
+  private UserStatus status;
+
+  @Column(name = "manner_score", nullable = false)
+  @Comment("매너 점수")
+  private Integer mannerScore;
+
+  @Column(name = "joined_group_id", nullable = true)
+  @Comment("가입한 그룹의 아이디")
+  private Long joinedGroupId;
+
+  @Column(name = "created_group_id")
+  @Comment("본인이 만든 그룹 아이디")
+  private Long createdGroupId;
+
+  @CreatedDate
+  @Column(name = "created_at", updatable = false)
+  @Comment("User 생성 일자")
+  private LocalDateTime createdAt;
+
+  @LastModifiedDate
+  @Comment("User 업데이트 일자")
+  @Column(name = "updated_at")
+  private LocalDateTime updatedAt;
 
 
   private User(String email, String password, int age, Gender gender, Address address,
-      String nickname, String phoneNumber, Role role, String profileImageUrl) {
+      String nickname, String phoneNumber, Role role, String profileUrl, UserStatus status,
+      Integer mannerScore, Long createdGroupId, Long joinedGroupId) {
     this.email = email;
     this.password = password;
     this.age = age;
@@ -97,15 +132,21 @@ public class User {
     this.nickname = nickname;
     this.phoneNumber = phoneNumber;
     this.role = role;
-    this.profileImageUrl = profileImageUrl;
+    this.profileUrl = profileUrl;
+    this.status = status;
+    this.mannerScore = mannerScore;
+    this.createdGroupId = createdGroupId;
+    this.joinedGroupId = joinedGroupId;
   }
 
   // @VisibleForTesting
   public static User createWithIdForTest(
       Long id, String email, String password, int age, Gender gender, Address address,
-      String nickname, String phoneNumber, Role role, String profileImageUrl
+      String nickname, String phoneNumber, Role role, String profileUrl, UserStatus status,
+      Integer mannerScore, Long createdGroupId, Long joinedGroupId
   ) {
-    User user = new User(email, password, age, gender, address, nickname, phoneNumber, role, profileImageUrl);
+    User user = new User(email, password, age, gender, address, nickname, phoneNumber, role,
+        profileUrl, status, mannerScore, createdGroupId, joinedGroupId);
     user.id = id;
     return user;
   }
@@ -121,9 +162,23 @@ public class User {
       @NotBlank String nickname,
       @NotBlank String phoneNumber,
       @NotBlank Role role,
-      String profileImageUrl
+      String profileUrl
   ) {
-    return new User(email, password, age, gender, address, nickname, phoneNumber, role, profileImageUrl);
+    return new User(
+        email,
+        password,
+        age,
+        gender,
+        address,
+        nickname,
+        phoneNumber,
+        role,
+        profileUrl,
+        UserStatus.ACTIVE,
+        60,
+        null,
+        null
+    );
   }
 
 
@@ -137,55 +192,74 @@ public class User {
         user.email) && Objects.equals(password, user.password) && Objects.equals(
         nickname, user.nickname) && gender == user.gender && Objects.equals(address,
         user.address) && Objects.equals(phoneNumber, user.phoneNumber) && role == user.role
-        && Objects.equals(profileImageUrl, user.profileImageUrl);
+        && Objects.equals(profileUrl, user.profileUrl) && status == user.status
+        && Objects.equals(mannerScore, user.mannerScore) && Objects.equals(
+        joinedGroupId, user.joinedGroupId) && Objects.equals(createdGroupId,
+        user.createdGroupId) && Objects.equals(createdAt, user.createdAt)
+        && Objects.equals(updatedAt, user.updatedAt);
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(id, email, password, nickname, age, gender, address, phoneNumber, role,
-        profileImageUrl);
+        profileUrl, status, mannerScore, joinedGroupId, createdGroupId, createdAt, updatedAt);
   }
 
   public void updateFrom(UserUpdateRequest dto) {
-    boolean isUpdated = false;
+    updateEmailIfChanged(dto.email());
+    updateAgeIfChanged(dto.age());
+    updateGenderIfChanged(dto.gender());
+    updateNicknameIfChanged(dto.nickname());
+    updatePhoneNumberIfChanged(dto.phoneNumber());
+    updateProfileUrlIfChanged(dto.profileUrl());
+    updateAddressIfChanged(dto.address());
+  }
 
-    if (dto.age() != null && this.age != dto.age()) {
-      updateAge(dto.age());
-      isUpdated = true;
-    }
-    if (dto.gender() != null && this.gender != dto.gender()) {
-      updateGender(dto.gender());
-      isUpdated = true;
-    }
-    if (dto.address() != null && !this.address.equals(dto.address().toAddress())) {
-      updateAddress(dto.address());
-      isUpdated = true;
-    }
-    if (dto.nickname() != null && !this.nickname.equals(dto.nickname())) {
-      updateNickname(dto.nickname());
-      isUpdated = true;
-    }
-    if (dto.phoneNumber() != null && !this.phoneNumber.equals(dto.phoneNumber())) {
-      updatePhoneNumber(dto.phoneNumber());
-      isUpdated = true;
-    }
-
-    if (!isUpdated) {
-      throw new IllegalArgumentException("변경된 내용이 없습니다.");
+  private void updateEmailIfChanged(String email) {
+    if (email != null && !this.email.equals(email)) {
+      this.email = email;
     }
   }
 
-  public void updateProfileImageUrl(String profileImageUrl) {
-    // 이건 추후 구현하도록 하자.
-    // 기존 update 코드와 분리시켜 개발할 예정
+  private void updateAgeIfChanged(Integer age) {
+    if (age != null && age >= 0 && this.age != age) {
+      this.age = age;
+    }
   }
 
-  public void updateNickname(String newNickname) {
-    if (newNickname == null || newNickname.isEmpty()) {
-      throw new IllegalArgumentException("닉네임은 null일 수 없습니다.");
+  private void updateGenderIfChanged(Gender gender) {
+    if (gender != null && this.gender != gender) {
+      this.gender = gender;
     }
-    this.nickname = newNickname;
   }
+
+  private void updateNicknameIfChanged(String nickname) {
+    if (nickname != null && !this.nickname.equals(nickname)) {
+      this.nickname = nickname;
+    }
+  }
+
+  private void updatePhoneNumberIfChanged(String phoneNumber) {
+    if (phoneNumber != null && !this.phoneNumber.equals(phoneNumber)) {
+      this.phoneNumber = phoneNumber;
+    }
+  }
+
+  private void updateProfileUrlIfChanged(String profileUrl) {
+    if (profileUrl != null && !profileUrl.equals(this.profileUrl)) {
+      this.profileUrl = profileUrl;
+    }
+  }
+
+  private void updateAddressIfChanged(AddressRequest dto) {
+    if (dto == null) return;
+
+    Address newAddress = new Address(dto.state(), dto.city(), dto.street(), dto.zipCode());
+    if (!this.address.equals(newAddress)) {
+      this.address = newAddress;
+    }
+  }
+
 
   public void updatePassword(String newPassword) {
     if (newPassword == null || newPassword.length() < 6) {
@@ -194,44 +268,27 @@ public class User {
     this.password = newPassword;
   }
 
-  public void updateAge(Integer age) {
-    if (age < 0) {
-      throw new IllegalArgumentException("나이는 음수일 수 없습니다.");
+  public void activate() {
+    if (this.status == UserStatus.ACTIVE) {
+      throw new IllegalStateException("이미 활성화된 유저입니다.");
     }
-    this.age = age;
+    this.status = UserStatus.ACTIVE;
   }
 
-  public void updatePhoneNumber(String newPhoneNumber) {
-    if (newPhoneNumber == null) {
-      throw new IllegalArgumentException("전화번호는 null일 수 없습니다.");
+  public void suspend() {
+    if (this.status == UserStatus.BANNED) {
+      throw new IllegalStateException("영구 정지된 유저는 상태 변경이 불가합니다.");
     }
-    this.phoneNumber = newPhoneNumber;
-  }
-
-  public void updateGender(Gender gender) {
-    if (gender == null) {
-      throw new IllegalArgumentException("성별은 null일 수 없습니다.");
+    if (this.status == UserStatus.SUSPENDED) {
+      return;
     }
-    this.gender = gender;
+    this.status = UserStatus.SUSPENDED;
   }
 
-  public void updateAddress(AddressRequest address) {
-    if (address == null) {
-      throw new IllegalArgumentException("주소는 null일 수 없습니다.");
+  public void ban() {
+    if (this.status == UserStatus.BANNED) {
+      throw new IllegalStateException("이미 영구 정지된 유저여서 상태 변경이 불가능합니다.");
     }
-    this.address = new Address(
-        address.state(),
-        address.city(),
-        address.street(),
-        address.zipCode()
-    );
-  }
-
-  public boolean isAdmin() {
-    return this.role == Role.ADMIN;
-  }
-
-  public String getProfileImageUrl() {
-    return null;
+    this.status = UserStatus.BANNED;
   }
 }

--- a/src/main/java/com/rocket/domains/user/domain/enums/Role.java
+++ b/src/main/java/com/rocket/domains/user/domain/enums/Role.java
@@ -1,5 +1,13 @@
 package com.rocket.domains.user.domain.enums;
 
 public enum Role {
-  ADMIN, USER
+  ADMIN, USER;
+
+  public boolean isAdmin() {
+    return this == ADMIN;
+  }
+
+  public boolean isNotAdmin() {
+    return this != ADMIN;
+  }
 }

--- a/src/main/java/com/rocket/domains/user/domain/enums/UserStatus.java
+++ b/src/main/java/com/rocket/domains/user/domain/enums/UserStatus.java
@@ -1,0 +1,5 @@
+package com.rocket.domains.user.domain.enums;
+
+public enum UserStatus {
+  ACTIVE, SUSPENDED, BANNED
+}

--- a/src/test/java/com/rocket/domains/auth/application/service/AuthServiceImplUnitTest.java
+++ b/src/test/java/com/rocket/domains/auth/application/service/AuthServiceImplUnitTest.java
@@ -23,6 +23,7 @@ import com.rocket.domains.user.domain.entity.Address;
 import com.rocket.domains.user.domain.entity.User;
 import com.rocket.domains.user.domain.enums.Gender;
 import com.rocket.domains.user.domain.enums.Role;
+import com.rocket.domains.user.domain.enums.UserStatus;
 import com.rocket.domains.user.domain.facade.UserFacade;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -62,7 +63,7 @@ class AuthServiceImplUnitTest {
     );
 
     User user = User.createWithIdForTest(1L, dto.email(), dto.password(), 25, Gender.MALE,
-        new Address("서울", "강남", "테헤란로", "12345"), dto.nickname(),"01000000000" ,Role.USER, null);
+        new Address("서울", "강남", "테헤란로", "12345"), dto.nickname(),"01000000000" ,Role.USER, null, UserStatus.ACTIVE, 60, null, null);
 
     when(userFacade.registerUser(dto)).thenReturn(user);
     when(jwtProvider.createAccessToken(dto.email())).thenReturn("accessToken");
@@ -117,7 +118,7 @@ class AuthServiceImplUnitTest {
     String newRefreshToken = "newRefreshToken";
 
     User user = User.createWithIdForTest(1L, email, encodedPassword, 25, Gender.MALE,
-        new Address("서울", "강남", "테헤란로", "12345"), "nickname", "01000000000", Role.USER, null);
+        new Address("서울", "강남", "테헤란로", "12345"), "nickname", "01000000000", Role.USER, null, UserStatus.ACTIVE, 60, null, null);
 
     when(userFacade.findUserByEmail(email)).thenReturn(Optional.of(user));
     when(passwordEncoder.matches(rawPassword, encodedPassword)).thenReturn(true);
@@ -171,7 +172,7 @@ class AuthServiceImplUnitTest {
     String wrongPassword = "wrongPassword";
 
     User user = User.createWithIdForTest(1L, email, correctPassword, 25, Gender.MALE,
-        new Address("서울", "강남", "테헤란로", "12345"), "nickname", "01000000000", Role.USER, null);
+        new Address("서울", "강남", "테헤란로", "12345"), "nickname", "01000000000", Role.USER, null, UserStatus.ACTIVE, 60, null, null);
 
     when(userFacade.findUserByEmail(email)).thenReturn(Optional.of(user));
     when(passwordEncoder.matches(wrongPassword, correctPassword)).thenReturn(false);
@@ -235,7 +236,7 @@ class AuthServiceImplUnitTest {
         email, "password", "25", Gender.MALE, address, "nickname", "01000000000", Role.USER, null);
 
     User savedUser = User.createWithIdForTest(1L, email, "encodedPassword", 25,
-        Gender.MALE, new Address("서울", "강남", "테헤란로", "12345"), "nickname", "01000000000", Role.USER, null);
+        Gender.MALE, new Address("서울", "강남", "테헤란로", "12345"), "nickname", "01000000000", Role.USER, null, UserStatus.ACTIVE, 60, null, null);
 
     when(userFacade.registerUser(request)).thenReturn(savedUser);
     when(jwtProvider.createAccessToken(email)).thenReturn(accessToken);

--- a/src/test/java/com/rocket/domains/posts/application/service/PostLikeIntegrationTest.java
+++ b/src/test/java/com/rocket/domains/posts/application/service/PostLikeIntegrationTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.rocket.commons.exception.exceptions.DuplicateLikeException;
-import com.rocket.domains.auth.domain.service.AuthService;
 import com.rocket.domains.posts.domain.entity.Post;
 import com.rocket.domains.posts.domain.entity.PostLike;
 import com.rocket.domains.posts.domain.repository.PostLikeCacheRepository;
@@ -13,11 +12,13 @@ import com.rocket.domains.posts.domain.repository.PostWriter;
 import com.rocket.domains.posts.domain.service.PostService;
 import com.rocket.domains.posts.infrastructure.persistence.jpa.PostLikeRepository;
 import com.rocket.domains.user.application.dto.response.UserSimpleInfoResponse;
+import com.rocket.domains.user.domain.entity.Address;
 import com.rocket.domains.user.domain.entity.User;
+import com.rocket.domains.user.domain.enums.Gender;
+import com.rocket.domains.user.domain.enums.Role;
 import com.rocket.domains.user.domain.facade.UserFacade;
 import com.rocket.domains.user.domain.repository.UserWriter;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,9 +26,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
-import com.rocket.domains.user.domain.enums.Gender;
-import com.rocket.domains.user.domain.enums.Role;
-import com.rocket.domains.user.domain.entity.Address;
 
 @SpringBootTest
 @ActiveProfiles("test")
@@ -37,13 +35,20 @@ class PostLikeIntegrationTest {
 
   @Autowired
   private PostLikeService postLikeService;
-  @Autowired private PostService postService;
-  @Autowired private UserFacade userFacade;
-  @Autowired private PostWriter postWriter;
-  @Autowired private PostReader postReader;
-  @Autowired private PostLikeCacheRepository redisRepo;
-  @Autowired private PostLikeRepository postLikeRepository;
-  @Autowired private UserWriter userWriter;
+  @Autowired
+  private PostService postService;
+  @Autowired
+  private UserFacade userFacade;
+  @Autowired
+  private PostWriter postWriter;
+  @Autowired
+  private PostReader postReader;
+  @Autowired
+  private PostLikeCacheRepository redisRepo;
+  @Autowired
+  private PostLikeRepository postLikeRepository;
+  @Autowired
+  private UserWriter userWriter;
 
   private User user;
   private Post post;
@@ -59,8 +64,7 @@ class PostLikeIntegrationTest {
         "테스터",
         "01012345678",
         Role.USER,
-        null
-    );
+        null);
     userWriter.saveUser(user);
     post = Post.create("테스트 제목", "테스트 내용", user);
     postWriter.savePost(post);
@@ -125,8 +129,7 @@ class PostLikeIntegrationTest {
     User other = User.create(
         "other@rocket.com", "pass123423es", 28, Gender.FEMALE,
         new Address("부산", "해운대", "센텀대로", "54321"),
-        "다른유저", "01099998888", Role.USER, null
-    );
+        "다른유저", "01099998888", Role.USER, null);
 
     userWriter.saveUser(other);
 

--- a/src/test/java/com/rocket/domains/posts/application/service/PostServiceImplTest.java
+++ b/src/test/java/com/rocket/domains/posts/application/service/PostServiceImplTest.java
@@ -23,6 +23,7 @@ import com.rocket.domains.user.domain.entity.Address;
 import com.rocket.domains.user.domain.entity.User;
 import com.rocket.domains.user.domain.enums.Gender;
 import com.rocket.domains.user.domain.enums.Role;
+import com.rocket.domains.user.domain.enums.UserStatus;
 import com.rocket.domains.user.domain.facade.UserFacade;
 import com.rocket.domains.user.domain.service.UserLookupService;
 import java.util.List;
@@ -64,14 +65,27 @@ class PostServiceImplTest {
   void setUp() {
     // Given
     normalUser = User.createWithIdForTest(
-        1L, "test@example.com", "password123!", 25,
-        Gender.MALE, new Address("state", "city", "street", "11111"),
-        "testNick", "01099999999", Role.USER, null
+        1L,
+        "test@example.com",
+        "password",
+        30,
+        Gender.MALE,
+        new Address("sta", "dci", "sttr", "zc"),
+        "Toin",
+        "01001000000",
+        Role.USER,
+        null,
+        UserStatus.ACTIVE,
+        60,
+        null,
+        null
     );
+
     adminUser = User.createWithIdForTest(
         2L, "admin@example.com", "adminPass!!!", 30,
         Gender.FEMALE, new Address("st", "ct", "st", "22222"),
-        "adminNick", "01088888888", Role.ADMIN, null
+        "adminNick", "01088888888", Role.ADMIN, null, UserStatus.ACTIVE,
+        70, null, null
     );
 
     samplePost = Post.create("SampleTitle", "SampleContent", normalUser);
@@ -85,15 +99,19 @@ class PostServiceImplTest {
   // ------------------------------------------
   private User createUser(Long id, Role role) {
     User user = User.createWithIdForTest(
-        id,                           // id
-        "test@example.com",                  // email
-        "password123!",                      // password
-        25,                                  // age
-        Gender.MALE,                         // gender
-        new Address("state", "city", "street", "11111"), // address
-        "testNick",                          // nickname
-        "01099999999",                       // phoneNumber
-        role,                            // role
+        1L,
+        "test@example.com",
+        "password",
+        30,
+        Gender.MALE,
+        new Address("st", "ci", "stt1r", "zc"),
+        "Toin",
+        "01001000000",
+        Role.USER,
+        null,
+        UserStatus.ACTIVE,
+        60,
+        null,
         null
     );
 

--- a/src/test/java/com/rocket/domains/user/application/service/UserServiceImplTest.java
+++ b/src/test/java/com/rocket/domains/user/application/service/UserServiceImplTest.java
@@ -18,8 +18,10 @@ import com.rocket.domains.user.domain.entity.Address;
 import com.rocket.domains.user.domain.entity.User;
 import com.rocket.domains.user.domain.enums.Gender;
 import com.rocket.domains.user.domain.enums.Role;
+import com.rocket.domains.user.domain.enums.UserStatus;
 import com.rocket.domains.user.domain.repository.UserReader;
 import com.rocket.domains.user.domain.repository.UserWriter;
+import com.rocket.domains.user.domain.validator.UserValidator;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -41,8 +43,13 @@ class UserServiceImplTest {
   @Mock
   private PasswordEncoder passwordEncoder;
 
+  @Mock
+  private UserValidator userValidator;
+
   @InjectMocks
   private UserServiceImpl userService;
+
+
 
   private User user;
   private UserRegisterRequest userRegisterRequest;
@@ -55,8 +62,22 @@ class UserServiceImplTest {
     MockitoAnnotations.openMocks(this);
     Address address = new Address("State", "City", "Street", "Zip");
     // 테스트 전용 정적 메서드를 사용하여 ID를 포함한 User 객체 생성
-    user = createWithIdForTest(1L, "test@example.com", "password", 30, Gender.MALE, address,
-        "Toin", "01001000000", Role.USER, null);
+    user = user = createWithIdForTest(
+        1L,
+        "test@example.com",
+        "password",
+        30,
+        Gender.MALE,
+        new Address("State", "City", "Street", "Zip"),
+        "Toin",
+        "01001000000",
+        Role.USER,
+        null,
+        UserStatus.ACTIVE,
+        60,
+        null,
+        null
+    );
 
     // 비밀번호 암호화 스텁: 모든 입력에 대해 "encodedPassword"를 반환합니다.
     when(passwordEncoder.encode(any(CharSequence.class))).thenReturn("encodedPassword");
@@ -77,7 +98,7 @@ class UserServiceImplTest {
         35,
         Gender.FEMALE,
         new AddressRequest("State", "City", "NewStreet", "Zip"),
-        "Toni", "01000000000"
+        "Toni", "01000000000", null
     );
 
     // 응답용 UserDTO 생성 (User -> DTO 변환)
@@ -148,8 +169,22 @@ class UserServiceImplTest {
     when(userReader.findByEmail(anyString())).thenReturn(Optional.ofNullable(user));
 
     Address updatedAddress = new Address("State", "City", "NewStreet", "Zip");
-    User updatedUser = createWithIdForTest(1L, "test@example.com", "password", 35, Gender.FEMALE,
-        updatedAddress, "Toni", "010000300000", Role.USER, null);
+    User updatedUser = createWithIdForTest(
+        1L,
+        "test@example.com",
+        "password",
+        30,
+        Gender.MALE,
+        new Address("State", "City", "Street", "Zip"),
+        "Toin",
+        "01001070500",
+        Role.USER,
+        null,
+        UserStatus.ACTIVE,
+        60,
+        null,
+        null
+    );
     when(userReader.findByEmail(anyString())).thenReturn(Optional.of(updatedUser));
 
     // When
@@ -160,19 +195,6 @@ class UserServiceImplTest {
     assertThat(result.age()).isEqualTo(35);
     assertThat(result.gender()).isEqualTo(Gender.FEMALE);
     // 각 업데이트 메서드 호출 여부는 Repository 구현에 따라 verify 추가 가능
-  }
-
-  @DisplayName("User 수정 by email - 실패 (수정할 내용 없음)")
-  @Test
-  void updateByEmail_fail_noUpdateFields() {
-    // Given: 업데이트할 필드가 모두 null인 경우
-    UserUpdateRequest updateDTO = new UserUpdateRequest("test@example.com", null, null, null, null, null);
-    when(userReader.findByEmail(anyString())).thenReturn(Optional.ofNullable(user));
-
-    // When & Then: 변경할 내용이 없으면 예외 발생
-    assertThatThrownBy(() -> userService.updateByEmail(updateDTO))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("변경된 내용이 없습니다.");
   }
 
   @DisplayName("User 수정 by email - 실패 (사용자 없음)")


### PR DESCRIPTION
## ✨ 주요 변경 사항

- User 엔티티를 ERD와 동기화하여 필드 및 로직 리팩토링
- mannerScore, status, createdGroupId, joinedGroupId 필드 추가 및 기본값 설정
- 상태 변경 메서드 분리 (`activate`, `suspend`, `ban`)
- `updateFrom()` 메서드를 필드 단위로 분리하여 가독성 및 유지보수성 향상
- 생성/수정일 자동 반영을 위한 JPA Auditing 활성화
- 테스트 코드 수정: 생성자/빌더 변경에 따른 createWithIdForTest 정비

---

## 🧠 작업 배경 및 이유

- 기존 User 엔티티는 ERD와 불일치한 필드가 다수 존재했고,
- 책임 분리가 명확하지 않아 확장 시 어려움이 예상되었습니다.
- 추후 그룹 연동, 매너 점수 시스템, 신고 처리 등의 기능 확장을 위한 기반을 마련하고자 리팩토링을 진행했습니다.

---

## ⚠️ 이슈/주의사항

- 이 PR은 DB 구조 변경을 포함하므로, 마이그레이션 여부를 고려해야 합니다.
- 기존 테스트 코드 중 User 생성 방식에 의존한 부분은 수정되었습니다.

---

## ✅ 관련 이슈

- Closes #18 
